### PR TITLE
Match raw video ids

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -217,7 +217,11 @@ exports.between = function(haystack, left, right) {
  * @param {String} link
  * @return {String}
  */
+var idRegex = /^[a-zA-Z0-9-_]{11}$/;
 exports.getVideoID = function(link) {
+  if (idRegex.test(link)) {
+    return link;
+  }
   var parsed = url.parse(link, true);
   var id = parsed.query.v;
   if (parsed.hostname === 'youtu.be' || !id) {

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -230,6 +230,8 @@ describe('util.getVideoID()', function() {
     assert(id, 'VIDEO_ID');
     id = util.getVideoID('http://youtube.com/embed/VIDEO_ID');
     assert(id, 'VIDEO_ID');
+    id = util.getVideoID('RAW_VIDEOID'); // Video ids are 11-character long
+    assert(id, 'RAW_VIDEOID');
   });
 });
 


### PR DESCRIPTION
Currently, ytdl-core only accepts URLs, this PR allows it to accept raw IDs such as `ysz0RxGyR_Y` using a fast regular expression.