### PR TITLE
Add the channel & video link to information

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -202,8 +202,8 @@ function gotConfig(id, options, additional, config, callback) {
             });
           }
           info.formats.sort(util.sortFormats);
-          info.channel_link = (info.ucid ? `https://www.youtube.com/channel/${info.ucid}` : "No UCID");
-          info.video_link = (info.video_id ? `https://www.youtube.com/watch?v=${info.video_id}` : "No VIDEO_ID");
+          info.channel_link = (info.ucid ? "https://www.youtube.com/channel/" + info.ucid : "No UCID");
+          info.video_link = (info.video_id ? "https://www.youtube.com/watch?v=" + info.video_id : "No VIDEO_ID");
           callback(null, info);
         });
       });

--- a/lib/info.js
+++ b/lib/info.js
@@ -202,6 +202,8 @@ function gotConfig(id, options, additional, config, callback) {
             });
           }
           info.formats.sort(util.sortFormats);
+          info.channel_link = (info.ucid ? `https://www.youtube.com/channel/${info.ucid}` : "No UCID");
+          info.video_link = (info.video_id ? `https://www.youtube.com/watch?v=${info.video_id}` : "No VIDEO_ID");
           callback(null, info);
         });
       });


### PR DESCRIPTION
It'd be awesome to be able to just get the channel link or video link by doing info.channel_link or info.video_link, so I propose this.