### PR TITLE
continue after econnreset

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ An example of what Info and format may look like is in the [example folder](exam
 #### Event: 'response'
 * `http.ServerResponse` - Response.
 
-Emitted when the video response has been found, and has started downloading. Can be used to get the size of download. This is also emitted if there is an error with the download.
+Emitted when the video response has been found, and has started downloading. Can be used to get the size of download. This is also emitted if there is an error with the download or it needs to reconnect to YouTube.
 
 #### Event: 'progress'
 * `number` - Percentage.
 * `number` - Start.
 * `number` - End.
-* `number` - Downloaded.
-* `number` - Chunk.
+* `number` - Total downloaded.
+* `number` - Chunk length.
 
 Emitted whenever a new chunk is received. Passes values descriping the download progress and the parsed percentage.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Attempts to download a video from the given url. Returns a readable stream. `opt
 * `quality` - Video quality to download. Can be an [itag value](http://en.wikipedia.org/wiki/YouTube#Quality_and_formats) value, a list of itag values, or `highest`/`lowest`. Defaults to `highest`.
 * `filter` - Can be `video` to filter for formats that contain video, `videoonly` for formats that contain video and no additional audio track. Can also be `audio` or `audioonly`. You can give a filtering function that gets called with each format available. Used to decide what format to download. This function is given the `format` object as its first argument, and should return true if the format is preferable.
 * `format` - This can be a specific `format` object returned from `getInfo`. This is primarily used to download specific video or audio streams. **Note:** Supplying this option will ignore the `filter` and `quality` options since the format is explicitly provided.
-* `range` - A byte range in the form `INT-INT` that specifies part of the file to download. ie 10355705-12452856. Note that this downloads a portion of the file, and not a separately spliced video.
+* `range` - A byte range in the form `{start: INT, end: INT}` that specifies part of the file to download. ie {start: 10355705, end: 12452856}. Note that this downloads a portion of the file, and not a separately spliced video.
 * `begin` - What time to begin downloading the video, supports formats 00:00:00.000, or 0ms, 0s, 0m, 0h, or number of milliseconds. Example: 1:30, 05:10.123, 10m30s
 * `requestOptions` - Anything to merge into the request options which `http.get()` is called with, such as headers.
 * `request` - A function that will be called for each request, instead of ytdl's internal method of making requests. Its signature looks like `Function(url, options, [callback(error, body)]): http.ClientRequest`
@@ -50,6 +50,15 @@ An example of what Info and format may look like is in the [example folder](exam
 * `http.ServerResponse` - Response.
 
 Emitted when the video response has been found, and has started downloading. Can be used to get the size of download. This is also emitted if there is an error with the download.
+
+#### Event: 'progress'
+* `number` - Percentage.
+* `number` - Start.
+* `number` - End.
+* `number` - Downloaded.
+* `number` - Chunk.
+
+Emitted whenever a new chunk is received. Passes values descriping the download progress and the parsed percentage.
 
 ### Stream#destroy()
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,9 @@ An example of what Info and format may look like is in the [example folder](exam
 Emitted when the video response has been found, and has started downloading. Can be used to get the size of download. This is also emitted if there is an error with the download or it needs to reconnect to YouTube.
 
 #### Event: 'progress'
-* `number` - Percentage.
-* `number` - Start.
-* `number` - End.
-* `number` - Total downloaded.
-* `number` - Chunk length.
+* `int` - Chunk length.
+* `int` - Total downloaded.
+* `int` - Total download length.
 
 Emitted whenever a new chunk is received. Passes values descriping the download progress and the parsed percentage.
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ An example of what Info and format may look like is in the [example folder](exam
 Emitted when the video response has been found, and has started downloading. Can be used to get the size of download. This is also emitted if there is an error with the download or it needs to reconnect to YouTube.
 
 #### Event: 'progress'
-* `int` - Chunk length.
-* `int` - Total downloaded.
-* `int` - Total download length.
+* `Number` - Chunk length.
+* `Number` - Total downloaded.
+* `Number` - Total download length.
 
 Emitted whenever a new chunk is received. Passes values descriping the download progress and the parsed percentage.
 

--- a/example/progress.js
+++ b/example/progress.js
@@ -7,6 +7,6 @@ var output = path.resolve(__dirname, 'video.mp4');
 
 var video = ytdl(url);
 video.pipe(fs.createWriteStream(output));
-video.on('progress', function(percentage, start, end, totalDownloaded, chunkLength) {
-  process.stdout.write((percentage * 100).toFixed(2) + '% ');
+video.on('progress', function(chunkLength, totalDownloaded, totalDownloadLength) {
+  process.stdout.write((totalDownloaded / totalDownloadLength * 100).toFixed(2) + '% ');
 });

--- a/example/progress.js
+++ b/example/progress.js
@@ -7,17 +7,6 @@ var output = path.resolve(__dirname, 'video.mp4');
 
 var video = ytdl(url);
 video.pipe(fs.createWriteStream(output));
-video.on('response', function(res) {
-  var totalSize = res.headers['content-length'];
-  var dataRead = 0;
-  res.on('data', function(data) {
-    dataRead += data.length;
-    var percent = dataRead / totalSize;
-    process.stdout.cursorTo(0);
-    process.stdout.clearLine(1);
-    process.stdout.write((percent * 100).toFixed(2) + '% ');
-  });
-  res.on('end', function() {
-    process.stdout.write('\n');
-  });
+video.on('progress', function(percentage, start, end, totalDownloaded, chunkLength) {
+  process.stdout.write((percentage * 100).toFixed(2) + '% ');
 });

--- a/example/range.js
+++ b/example/range.js
@@ -5,7 +5,7 @@ var ytdl = require('..');
 var url = 'https://www.youtube.com/watch?v=CehAKQL463M';
 var output = path.resolve(__dirname, 'video.mp4');
 
-var video = ytdl(url, { range: '0-1000' });
+var video = ytdl(url, { range: { start: 0, end: 1000 } });
 video.pipe(fs.createWriteStream(output));
 
 video.on('end', function() {

--- a/example/range.js
+++ b/example/range.js
@@ -9,6 +9,6 @@ var video = ytdl(url, { range: { start: 0, end: 1000 } });
 video.pipe(fs.createWriteStream(output));
 
 video.on('end', function() {
-  ytdl(url, { range: '1001-' })
+  ytdl(url, { range: { start: 0 } })
     .pipe(fs.createWriteStream(output, { flags: 'a' }));
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,9 +66,9 @@ function downloadFromInfoCallback(stream, info, options) {
     trys: 5,
     range: {
       start: options.range ? (options.range.start ? options.range.start : 0) : 0,
-      end: options.range ? (options.range.end ? options.range.end : -1) : -1
+      end: options.range ? (options.range.end ? options.range.end : -1) : -1,
     },
-    downloaded: 0
+    downloaded: 0,
   });
 }
 
@@ -83,7 +83,7 @@ var redirectCodes = new Set([301, 302, 303, 307]);
  * @param {String} url
  * @param {Object} options
  * @param {Number} tryCount Prevent infinite redirects.
- * @param {Object} reconnectInfo
+ * @param {Object} reconnectInfo Continue after ECONNRESET
  */
 function doDownload(stream, url, options, tryCount, reconnectInfo) {
   if (stream._isDestroyed) { return; }
@@ -100,7 +100,7 @@ function doDownload(stream, url, options, tryCount, reconnectInfo) {
   var myrequest = options.request || request;
   var tempUrl = url;
   if (reconnectInfo.downloaded != 0 || reconnectInfo.range.start != 0 || reconnectInfo.range.end != -1) {
-    tempUrl += '&range=' + (reconnectInfo.range.start + reconnectInfo.downloaded) + '-' + (reconnectInfo.range.end != -1 ? reconnectInfo.range.end : '')
+    tempUrl += '&range=' + (reconnectInfo.range.start + reconnectInfo.downloaded) + '-' + (reconnectInfo.range.end != -1 ? reconnectInfo.range.end : '');
   }
   var req = myrequest(tempUrl, options.requestOptions);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,8 +65,8 @@ function downloadFromInfoCallback(stream, info, options) {
   doDownload(stream, url, options, 3, {
     trys: 5,
     range: {
-      start: options.range ? (options.range.start ? options.range.start : 0) : 0,
-      end: options.range ? (options.range.end ? options.range.end : -1) : -1,
+      start: options.range && options.range.start ? options.range.start : 0,
+      end: options.range && options.range.end ? options.range.end : -1,
     },
     downloaded: 0,
   });
@@ -98,11 +98,11 @@ function doDownload(stream, url, options, tryCount, reconnectInfo) {
 
   // Start downloading the video.
   var myrequest = options.request || request;
-  var tempUrl = url;
-  if (reconnectInfo.downloaded != 0 || reconnectInfo.range.start != 0 || reconnectInfo.range.end != -1) {
-    tempUrl += '&range=' + (reconnectInfo.range.start + reconnectInfo.downloaded) + '-' + (reconnectInfo.range.end != -1 ? reconnectInfo.range.end : '');
+  var rangedUrl = url;
+  if (reconnectInfo.downloaded !== 0 || reconnectInfo.range.start !== 0 || reconnectInfo.range.end !== -1) {
+    rangedUrl += '&range=' + (reconnectInfo.range.start + reconnectInfo.downloaded) + '-' + (reconnectInfo.range.end != -1 ? reconnectInfo.range.end : '');
   }
-  var req = myrequest(tempUrl, options.requestOptions);
+  var req = myrequest(rangedUrl, options.requestOptions);
 
   var myres;
   stream.destroy = function() {
@@ -133,15 +133,22 @@ function doDownload(stream, url, options, tryCount, reconnectInfo) {
       return;
     }
 
-    reconnectInfo.range.end = reconnectInfo.range.end === -1 ? parseInt(res.headers['content-length']) : (parseInt(res.headers['content-length']) < reconnectInfo.range.end ? parseInt(res.headers['content-length']) : reconnectInfo.range.end);
+    if(reconnectInfo.downloaded === 0) {
+      var res_length = parseInt(res.headers['content-length']);
+      var end = reconnectInfo.range.end;
+      var shortest_length = Math.min(res_length, end);
+      reconnectInfo.range.end = end === -1 ? res_length : shortest_length;
+    }
+    // Keep track of the download progress
     res.on('data', function(d) {
       reconnectInfo.downloaded += d.length;
       stream.emit('progress', reconnectInfo.downloaded / (reconnectInfo.range.end - reconnectInfo.range.start), reconnectInfo.range.start, reconnectInfo.range.end, reconnectInfo.downloaded, d.length);
     });
 
-    res.pipe(stream, {end : false});  //not sure wether this pipes errors...
+    res.pipe(stream, {end : false});  // Not piping errors...
     res.on('end', function() {
       stream.unpipe(res);
+      // Restart the stream if it hasn't reached the end
       if (reconnectInfo.downloaded + reconnectInfo.range.start < reconnectInfo.range.end) {
         reconnectInfo.trys = reconnectInfo.trys - 1;
         doDownload(stream, url, options, tryCount, reconnectInfo);

--- a/lib/index.js
+++ b/lib/index.js
@@ -133,16 +133,16 @@ function doDownload(stream, url, options, tryCount, reconnectInfo) {
       return;
     }
 
-    if(reconnectInfo.downloaded === 0) {
-      var res_length = parseInt(res.headers['content-length']);
+    if (reconnectInfo.downloaded === 0) {
+      var resLength = parseInt(res.headers['content-length']);
       var end = reconnectInfo.range.end;
-      var shortest_length = Math.min(res_length, end);
-      reconnectInfo.range.end = end === -1 ? res_length : shortest_length;
+      var shortestLength = Math.min(resLength, end);
+      reconnectInfo.range.end = end === -1 ? resLength : shortestLength;
     }
     // Keep track of the download progress
     res.on('data', function(d) {
       reconnectInfo.downloaded += d.length;
-      stream.emit('progress', reconnectInfo.downloaded / (reconnectInfo.range.end - reconnectInfo.range.start), reconnectInfo.range.start, reconnectInfo.range.end, reconnectInfo.downloaded, d.length);
+      stream.emit('progress', d.length, reconnectInfo.downloaded, reconnectInfo.range.end - reconnectInfo.range.start);
     });
 
     res.pipe(stream, {end : false});  // Not piping errors...

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,14 +58,18 @@ function downloadFromInfoCallback(stream, info, options) {
   stream.emit('info', info, format);
 
   var url = format.url;
-  if (options.range) {
-    url += '&range=' + options.range;
-  }
   if (options.begin) {
     url += '&begin=' + util.fromHumanTime(options.begin);
   }
 
-  doDownload(stream, url, options, 3);
+  doDownload(stream, url, options, 3, {
+    trys: 5,
+    range: {
+      start: options.range ? (options.range.start ? options.range.start : 0) : 0,
+      end: options.range ? (options.range.end ? options.range.end : -1) : -1
+    },
+    downloaded: 0
+  });
 }
 
 
@@ -79,17 +83,26 @@ var redirectCodes = new Set([301, 302, 303, 307]);
  * @param {String} url
  * @param {Object} options
  * @param {Number} tryCount Prevent infinite redirects.
+ * @param {Object} reconnectInfo
  */
-function doDownload(stream, url, options, tryCount) {
+function doDownload(stream, url, options, tryCount, reconnectInfo) {
   if (stream._isDestroyed) { return; }
   if (tryCount === 0) {
     stream.emit('error', new Error('Too many redirects'));
     return;
   }
+  if (reconnectInfo.trys === 0) {
+    stream.emit('error', new Error('Too many reconnects'));
+    return;
+  }
 
   // Start downloading the video.
   var myrequest = options.request || request;
-  var req = myrequest(url, options.requestOptions);
+  var tempUrl = url;
+  if (reconnectInfo.downloaded != 0 || reconnectInfo.range.start != 0 || reconnectInfo.range.end != -1) {
+    tempUrl += '&range=' + (reconnectInfo.range.start + reconnectInfo.downloaded) + '-' + (reconnectInfo.range.end != -1 ? reconnectInfo.range.end : '')
+  }
+  var req = myrequest(tempUrl, options.requestOptions);
 
   var myres;
   stream.destroy = function() {
@@ -120,7 +133,23 @@ function doDownload(stream, url, options, tryCount) {
       return;
     }
 
-    res.pipe(stream);
+    reconnectInfo.range.end = reconnectInfo.range.end === -1 ? parseInt(res.headers['content-length']) : reconnectInfo.range.end;
+    res.on('data', function(d) {
+      reconnectInfo.downloaded += d.length;
+      stream.emit('progress', reconnectInfo.downloaded / (reconnectInfo.range.end - reconnectInfo.range.start), reconnectInfo.range.start, reconnectInfo.range.end, reconnectInfo.downloaded, d.length);
+    });
+
+    res.pipe(stream, {end : false});
+    res.on('end', function() {
+      stream.unpipe(res);
+      if (reconnectInfo.downloaded + reconnectInfo.range.start < reconnectInfo.range.end) {
+        reconnectInfo.trys = reconnectInfo.trys - 1;
+        doDownload(stream, url, options, tryCount, reconnectInfo);
+        return;
+      }
+      stream.end();
+    });
+
     stream.emit('response', res);
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,13 +116,13 @@ function doDownload(stream, url, options, tryCount, reconnectInfo) {
 
   req.on('error', function(err) {
     console.log('req error "'+err.toString()+'"');
-    if(err.toString.includes('ECONNRESET') || err.toString.includes('ECONNREFUSED')) {
-      req.abort();
+    //if(err && (err.toString().includes('ECONNRESET') || err.toString().includes('ECONNREFUSED'))) {
+      //req.abort();
       // should restart anyway 'cause res should end
       //reconnectInfo.trys = reconnectInfo.trys - 1;
       //doDownload(stream, url, options, tryCount, reconnectInfo);
-      return;
-    }
+      //return;
+    //}
     stream.emit('error', err);
   });
 
@@ -130,13 +130,13 @@ function doDownload(stream, url, options, tryCount, reconnectInfo) {
     myres = res;
     res.on('error', function (err) {
       console.log('res error "'+err.toString()+'"');
-      if(err.toString.includes('ECONNRESET') || err.toString.includes('ECONNREFUSED')) {
-        req.abort();
+      //if(err && (err.toString().includes('ECONNRESET') || err.toString().includes('ECONNREFUSED'))) {
+        //req.abort();
         // should restart anyway 'cause res should end
         //reconnectInfo.trys = reconnectInfo.trys - 1;
         //doDownload(stream, url, options, tryCount, reconnectInfo);
-        return;
-      }
+        //return;
+      // }
     });
     res.on('end', function() {
       console.log('res end');
@@ -164,6 +164,7 @@ function doDownload(stream, url, options, tryCount, reconnectInfo) {
     // Keep track of the download progress
     res.on('data', function(d) {
       reconnectInfo.downloaded += d.length;
+      console.log('progress', reconnectInfo.downloaded / (reconnectInfo.range.end - reconnectInfo.range.start))
       stream.emit('progress', d.length, reconnectInfo.downloaded, reconnectInfo.range.end - reconnectInfo.range.start);
     });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,11 +115,33 @@ function doDownload(stream, url, options, tryCount, reconnectInfo) {
   };
 
   req.on('error', function(err) {
+    console.log('req error "'+err.toString()+'"');
+    if(err.toString.includes('ECONNRESET') || err.toString.includes('ECONNREFUSED')) {
+      req.abort();
+      // should restart anyway 'cause res should end
+      //reconnectInfo.trys = reconnectInfo.trys - 1;
+      //doDownload(stream, url, options, tryCount, reconnectInfo);
+      return;
+    }
     stream.emit('error', err);
   });
 
   req.on('response', function(res) {
     myres = res;
+    res.on('error', function (err) {
+      console.log('res error "'+err.toString()+'"');
+      if(err.toString.includes('ECONNRESET') || err.toString.includes('ECONNREFUSED')) {
+        req.abort();
+        // should restart anyway 'cause res should end
+        //reconnectInfo.trys = reconnectInfo.trys - 1;
+        //doDownload(stream, url, options, tryCount, reconnectInfo);
+        return;
+      }
+    });
+    res.on('end', function() {
+      console.log('res end');
+    });
+
     if (stream._isDestroyed) { return; }
     // Support for Streaming 206 status videos
     if (res.statusCode !== 200 && res.statusCode !== 206) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -133,13 +133,13 @@ function doDownload(stream, url, options, tryCount, reconnectInfo) {
       return;
     }
 
-    reconnectInfo.range.end = reconnectInfo.range.end === -1 ? parseInt(res.headers['content-length']) : reconnectInfo.range.end;
+    reconnectInfo.range.end = reconnectInfo.range.end === -1 ? parseInt(res.headers['content-length']) : (parseInt(res.headers['content-length']) < reconnectInfo.range.end ? parseInt(res.headers['content-length']) : reconnectInfo.range.end);
     res.on('data', function(d) {
       reconnectInfo.downloaded += d.length;
       stream.emit('progress', reconnectInfo.downloaded / (reconnectInfo.range.end - reconnectInfo.range.start), reconnectInfo.range.start, reconnectInfo.range.end, reconnectInfo.downloaded, d.length);
     });
 
-    res.pipe(stream, {end : false});
+    res.pipe(stream, {end : false});  //not sure wether this pipes errors...
     res.on('end', function() {
       stream.unpipe(res);
       if (reconnectInfo.downloaded + reconnectInfo.range.start < reconnectInfo.range.end) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,7 @@ function doDownload(stream, url, options, tryCount, reconnectInfo) {
     if (res.statusCode !== 200 && res.statusCode !== 206) {
       if (redirectCodes.has(res.statusCode)) {
         // Redirection header.
-        doDownload(stream, res.headers.location, options, tryCount - 1);
+        doDownload(stream, res.headers.location, options, tryCount - 1, reconnectInfo);
         return;
       }
       stream.emit('response', res);

--- a/lib/info.js
+++ b/lib/info.js
@@ -18,6 +18,10 @@ var KEYS_TO_SPLIT = [
   'fexp',
   'watermark'
 ];
+var CONTENT_WARNINGS = [
+  'Content Warning',
+  'Inhaltswarnung'
+];
 
 
 /**
@@ -57,7 +61,7 @@ module.exports = function getInfo(link, options, callback) {
     if (!/\bhid\b/.test(util.between(unavailableMsg, 'class="', '"'))) {
       unavailableMsg = util.between(body, '<h1 id="unavailable-message" class="message">', '</h1>').trim();
       // Getting around age restricted videos.
-      if (unavailableMsg !== 'Content Warning') {
+      if (!CONTENT_WARNINGS.includes(unavailableMsg)) {
         return callback(new Error(unavailableMsg));
       }
     }

--- a/lib/info.js
+++ b/lib/info.js
@@ -18,10 +18,6 @@ var KEYS_TO_SPLIT = [
   'fexp',
   'watermark'
 ];
-var CONTENT_WARNINGS = new Set([
-  'Content Warning',
-  'Inhaltswarnung'
-]);
 
 
 /**
@@ -61,7 +57,7 @@ module.exports = function getInfo(link, options, callback) {
     if (!/\bhid\b/.test(util.between(unavailableMsg, 'class="', '"'))) {
       unavailableMsg = util.between(body, '<h1 id="unavailable-message" class="message">', '</h1>').trim();
       // Getting around age restricted videos.
-      if (!CONTENT_WARNINGS.has(unavailableMsg)) {
+      if (unavailableMsg !== 'Content Warning') {
         return callback(new Error(unavailableMsg));
       }
     }

--- a/lib/info.js
+++ b/lib/info.js
@@ -18,10 +18,10 @@ var KEYS_TO_SPLIT = [
   'fexp',
   'watermark'
 ];
-var CONTENT_WARNINGS = [
+var CONTENT_WARNINGS = new Set([
   'Content Warning',
   'Inhaltswarnung'
-];
+]);
 
 
 /**
@@ -61,7 +61,7 @@ module.exports = function getInfo(link, options, callback) {
     if (!/\bhid\b/.test(util.between(unavailableMsg, 'class="', '"'))) {
       unavailableMsg = util.between(body, '<h1 id="unavailable-message" class="message">', '</h1>').trim();
       // Getting around age restricted videos.
-      if (!CONTENT_WARNINGS.includes(unavailableMsg)) {
+      if (!CONTENT_WARNINGS.has(unavailableMsg)) {
         return callback(new Error(unavailableMsg));
       }
     }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "url": "git://github.com/fent/node-ytdl-core.git"
   },
   "author": "Roly Fentanes (https://github.com/fent)",
+  "contributors": [
+    "Tobias Kutscha (https://github.com/TimeForANinja)"
+  ],
   "main": "./lib/index.js",
   "scripts": {
     "test": "istanbul cover node_modules/.bin/_mocha -- -t 16000 test/*-test.js"

--- a/test/download-test.js
+++ b/test/download-test.js
@@ -164,9 +164,9 @@ describe('Download video', function() {
 
   describe('With range', function() {
     it('Range added to download URL', function(done) {
-      var stream = ytdl.downloadFromInfo(testInfo, { range: '500-1000' });
+      var stream = ytdl.downloadFromInfo(testInfo, { range: {start: 500, end: 1000} });
       stream.on('info', function(info, format) {
-        nock.url(format.url + '&range=500-1000').reply(200, '');
+        nock.url(format.url + '&range=500-1000').reply(200, '', {'content-length': '0'});
       });
       stream.resume();
       stream.on('error', done);

--- a/test/irl-test.js
+++ b/test/irl-test.js
@@ -26,7 +26,7 @@ describe('Try downloading videos without mocking', function() {
     describe(desc, function() {
       it('Request status code is not 403 Forbidden', function(done) {
         var stream = ytdl(video, { debug: false });
-        stream.on('response', function(res) {
+        stream.once('response', function(res) {
           assert.notEqual(res.statusCode, 403);
           res.destroy();
           done();


### PR DESCRIPTION
[x] restarting when the response stream ends before all data was received(up to 5 times)
[x] progress event since were already tracking it
[x] made content warnings easyer to adjust to each language
[x] kept the range options
[x] fixed tests
[x] fixed README

!! stream may emit 'response' multiple times
should also works as a workaround for #81 