### PR TITLE
-Fixes downloading of specific video issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,30 +60,38 @@ function downloadFromInfoCallback(stream, info, options) {
   }
   stream.emit('info', info, format);
   if (stream._isDestroyed) { return; }
-
   var url = format.url;
-  if (format.live) {
-    var req = m3u8stream(url, {
-      chunkReadahead: +info.live_chunk_readahead,
-      requestOptions: options.requestOptions,
-    });
-    req.on('error', stream.emit.bind(stream, 'error'));
-    stream.destroy = req.end.bind(req);
-    req.pipe(stream);
 
-  } else {
-    if (options.begin) {
-      url += '&begin=' + util.fromHumanTime(options.begin);
+  request(url, {}, function(err, res, body) {
+    if (err) {
+      format = util.chooseFormat(info.formats, {quality: 'baseline'});
+      url = format.url
     }
-    doDownload(stream, url, options, {
-      trys: options.retries || 5,
-      range: {
-        start: options.range && options.range.start ? options.range.start : 0,
-        end: options.range && options.range.end ? options.range.end : -1,
-      },
-      downloaded: 0,
-    });
-  }
+
+    if (format.live) {
+      var req = m3u8stream(url, {
+        chunkReadahead: +info.live_chunk_readahead,
+        requestOptions: options.requestOptions,
+      });
+      req.on('error', stream.emit.bind(stream, 'error'));
+      stream.destroy = req.end.bind(req);
+      req.pipe(stream);
+
+    } 
+    else {
+      if (options.begin) {
+        url += '&begin=' + util.fromHumanTime(options.begin);
+      }
+      doDownload(stream, url, options, {
+        trys: options.retries || 5,
+        range: {
+          start: options.range && options.range.start ? options.range.start : 0,
+          end: options.range && options.range.end ? options.range.end : -1,
+        },
+        downloaded: 0,
+      });
+    }
+  })
 }
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -127,6 +127,10 @@ exports.chooseFormat = function(formats, options) {
       format = formats[formats.length - 1];
       break;
 
+    case 'baseline': 
+      format = formats.find(function(format) {return format.profile == 'baseline'})
+      break;
+
     default:
       var getFormat = function(itag) {
         for (var i = 0, len = formats.length; i < len; i++) {


### PR DESCRIPTION
-Quality defaults to highest in chooseFormat function when users do not pass a quality option.
-Sometimes the highest quality video has an invalid or inaccessible URL that cannot be downloaded.
-This fixes the issue by performing a request to the URL and setting a fallback quality option on failure
so a user can still download a video.
-Also, included a new format called baseline.
-Resolves #163.