### PR TITLE
Request for iurlmaxres (Fixes #155) (Fix #2)

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -84,7 +84,17 @@ module.exports = function getInfo(link, options, callback) {
       iurlsd     : THUMBNAIL_URL + id + '/sddefault.jpg',
       iurlmq     : THUMBNAIL_URL + id + '/mqdefault.jpg',
       iurlhq     : THUMBNAIL_URL + id + '/hqdefault.jpg',
-      iurlmaxres : THUMBNAIL_URL + id + '/maxresdefault.jpg',
+      iurlmaxres : function getiurlmaxres(iurlcallback) {
+        var iurlmaxres = THUMBNAIL_URL + id + '/maxresdefault.jpg';
+        request(iurlmaxres, function(iurlerr, iurlres, iurlbody) {
+          if (iurlerr && iurlerr.message.includes("Status code: 404")) {
+            if (!callback) return new Promise(function(r, j) { return r(null)});
+            callback(null);
+          }
+          if (!callback) return new Promise(function(r, j) { return r(iurlmaxres) });
+          callback(iurlmaxres);
+        });
+      }
     };
 
     var jsonStr = util.between(body, 'ytplayer.config = ', '</script>');


### PR DESCRIPTION
This request should be able to fix the issue #155, by sending a request. YouTube, by default, sends a 404 status code response if it doesn't exist, and a 200 response if it does. By doing this, we make iurlmaxres a function, that way it only makes the request when they want it, and it will return null if 404.

If you want, I can remove the .message.includes and just have it set it null if it errored at all, but I think this may be the best method for what we want.