### PR TITLE
[Optimize] ID should be 11 number

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -236,7 +236,7 @@ exports.getVideoID = function(link) {
   if (!id) {
     return new Error('No video id found: ' + link);
   }
-  id = id.substring(0,11);
+  id = id.substring(0, 11);
   if (!idRegex.test(id)) {
     return new Error('Video id (' + id + ') does not match expected format (' + idRegex.toString() + ')');
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -236,6 +236,7 @@ exports.getVideoID = function(link) {
   if (!id) {
     return new Error('No video id found: ' + link);
   }
+  id = id.substring(0,11);
   if (!idRegex.test(id)) {
     return new Error('Video id (' + id + ') does not match expected format (' + idRegex.toString() + ')');
   }


### PR DESCRIPTION
Some url could be played such as : 
`https://www.youtube.com/watch?v=inRtVJMVlBk=lru?`
`https://www.youtube.com/watch?v=inRtVJMVlBk=XXXX`
 , but this lib could not parse successful, so I suggest we could cut the id to 11 length. 