### PR TITLE
Fix error message for videos that require purchase

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -136,6 +136,7 @@ function gotConfig(id, options, additional, config, appendConfig, callback) {
       gl: 'US',
       hl: (options.lang || 'en'),
       sts: config.sts,
+      el: 'info',
     },
   });
   request(url, options.requestOptions, function(err, res, body) {

--- a/lib/info.js
+++ b/lib/info.js
@@ -142,11 +142,11 @@ function gotConfig(id, options, additional, config, appendConfig, callback) {
   request(url, options.requestOptions, function(err, res, body) {
     if (err) return callback(err);
     var info = querystring.parse(body);
-    if (info.status === 'fail') {
-      info = config.args;
-    } else if (info.requires_purchase === '1') {
+    if (info.requires_purchase === '1') {
       return callback(new Error(info.ypc_video_rental_bar_text));
-    }
+    } else if (info.status === 'fail') {
+      info = config.args;
+    } 
 
     // Split some keys by commas.
     KEYS_TO_SPLIT.forEach(function(key) {


### PR DESCRIPTION
requires_purchase seems to only be reported if the request sets the el parameter to info. It seems the checks for requires_purchase were never reached before, so the error message was unspecific.