### PR TITLE
Don't add additional thumbnails. (Fixes #155)

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -10,7 +10,6 @@ const FORMATS     = require('./formats');
 const VIDEO_URL = 'https://www.youtube.com/watch?v=';
 const EMBED_URL = 'https://www.youtube.com/embed/';
 const VIDEO_EURL = 'https://youtube.googleapis.com/v/';
-const THUMBNAIL_URL = 'https://i.ytimg.com/vi/';
 const INFO_HOST = 'www.youtube.com';
 const INFO_PATH = '/get_video_info';
 const KEYS_TO_SPLIT = [
@@ -78,13 +77,7 @@ module.exports = function getInfo(link, options, callback) {
       related_videos: util.getRelatedVideos(body),
 
       // Give the canonical link to the video.
-      video_url: url,
-
-      // Thumbnails.
-      iurlsd     : THUMBNAIL_URL + id + '/sddefault.jpg',
-      iurlmq     : THUMBNAIL_URL + id + '/mqdefault.jpg',
-      iurlhq     : THUMBNAIL_URL + id + '/hqdefault.jpg',
-      iurlmaxres : THUMBNAIL_URL + id + '/maxresdefault.jpg',
+      video_url: url
     };
 
     var jsonStr = util.between(body, 'ytplayer.config = ', '</script>');

--- a/lib/info.js
+++ b/lib/info.js
@@ -77,7 +77,7 @@ module.exports = function getInfo(link, options, callback) {
       related_videos: util.getRelatedVideos(body),
 
       // Give the canonical link to the video.
-      video_url: url
+      video_url: url,
     };
 
     var jsonStr = util.between(body, 'ytplayer.config = ', '</script>');


### PR DESCRIPTION
This should fix issue [#155](https://github.com/fent/node-ytdl-core/issues/155).

Youtube API already provides us with the available thumbnails. Likewise if, for instance, `maxresdefault` isn't available the API doesn't return it. Adding them manually via the `additional` info object ends up causing this issue.

Doing something like this is possible now:
```js
var thumbnail = info.iurlmaxres || info.iurlmq;
```