### PR TITLE
rename validateId to validateLink

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ var ytdl = module.exports = function ytdl(link, options) {
 ytdl.getInfo = getInfo;
 ytdl.chooseFormat = util.chooseFormat;
 ytdl.filterFormats = util.filterFormats;
-ytdl.validateId = util.validateLink;
+ytdl.validateLink = util.validateLink;
 ytdl.cache = cache;
 
 


### PR DESCRIPTION
atm the `validateLink` function is named
validateLink in util
validateLink in typings
validateLink in readme
and
validateId in index.js

therefor i'd just rename it in index.js to fix #215 