### PR TITLE
Fix proxy example to actually transform URL

### DIFF
--- a/example/proxy.js
+++ b/example/proxy.js
@@ -1,14 +1,16 @@
 const ytdl = require('..');
 
 const stream = ytdl('https://www.youtube.com/watch?v=2UBFIhS1YBk', {
-  requestOptions: (parsed) => {
-    return {
-      host: '127.0.0.1',
-      port: 8888,
-      path: '/' + parsed.href,
-      headers: { Host: parsed.host },
-    };
-  },
+  requestOptions: {
+    transform: (parsed) => {
+      return {
+        host: '127.0.0.1',
+        port: 8888,
+        path: '/' + parsed.href,
+        headers: { Host: parsed.host },
+      };
+    },
+  }
 });
 
 console.log('Starting Download');


### PR DESCRIPTION
Fix https://github.com/fent/node-ytdl-core/issues/226

Fix proxy example to actually transform URL.

In the example, previously `parsed` was always `null`. It looks like we actually need to use the [`miniget` library, `requestsOptions.transform` option](https://github.com/fent/node-miniget/blob/c473618fda157a2bec2fed6a4b219ae877385179/lib/index.js#L51) to get the parsed URL data passed in.