### PR TITLE
(Mostly) Fixes Video unavailable bug

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -132,7 +132,7 @@ function gotConfig(id, options, additional, config, fromEmbed, callback) {
       gl: 'US',
       hl: (options.lang || 'en'),
       sts: config.sts,
-    }, fromEmbed ? {} : { el: 'info' }),
+    }),
   });
   request(url, options.requestOptions, (err, res, body) => {
     if (err) return callback(err);

--- a/lib/info.js
+++ b/lib/info.js
@@ -125,14 +125,14 @@ function gotConfig(id, options, additional, config, fromEmbed, callback) {
     protocol: 'https',
     host: INFO_HOST,
     pathname: INFO_PATH,
-    query: Object.assign({
+    query: {
       video_id: id,
       eurl: VIDEO_EURL + id,
       ps: 'default',
       gl: 'US',
       hl: (options.lang || 'en'),
       sts: config.sts,
-    }),
+    },
   });
   request(url, options.requestOptions, (err, res, body) => {
     if (err) return callback(err);


### PR DESCRIPTION
Quick fix so we have something that works most tests are passed the only one to fail is naturally 'No embed allowed' as I have modified something todo with embeds

```Try downloading videos without mocking
    Regular video
      ✓ Request status code is not 403 Forbidden (1792ms)
    VEVO
      ✓ Request status code is not 403 Forbidden (1356ms)
    VEVO 2
      ✓ Request status code is not 403 Forbidden (1516ms)
    Age restricted VEVO
      ✓ Request status code is not 403 Forbidden (1493ms)
    Age restricted
      ✓ Request status code is not 403 Forbidden (1872ms)
    Age restricted 2
      ✓ Request status code is not 403 Forbidden (1437ms)
    Embed domain restricted
      ✓ Request status code is not 403 Forbidden (1405ms)
    No embed allowed
      1) Request status code is not 403 Forbidden
```

I don't have a ton of time to devote to understanding whats wrong so here is just something so most peoples stuff works. Fent can do the rest :D