### PR TITLE
Change URL format in getInfo

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -80,7 +80,7 @@ module.exports = function getInfo(link, options, callback) {
       // Get related videos.
       related_videos: util.getRelatedVideos(body),
 
-      // Give the raw link to the video.
+      // Give the standard link to the video.
       video_url: VIDEO_URL + id,
     };
 

--- a/lib/info.js
+++ b/lib/info.js
@@ -80,8 +80,8 @@ module.exports = function getInfo(link, options, callback) {
       // Get related videos.
       related_videos: util.getRelatedVideos(body),
 
-      // Give the canonical link to the video.
-      video_url: url,
+      // Give the raw link to the video.
+      video_url: VIDEO_URL + id,
     };
 
     var jsonStr = util.between(body, 'ytplayer.config = ', '</script>');


### PR DESCRIPTION
When we set the URL on the return for info, it includes every parameter in the video. This is fine until you start wanting to compare this video to a saved URL you may have (This is just one use case). Using a standardized format, we should instead just put the raw URL. If requested, we could also put the parameters in a separate variable or even the URL with parameters in a second variable.