### PR TITLE
Move getBitrate func to fix crash in react native

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -119,6 +119,10 @@ exports.chooseFormat = (formats, options) => {
 
   var format;
   var quality = options.quality || 'highest';
+  function getBitrate(f) {
+    let s = f.bitrate.split('-');
+    return parseFloat(s[s.length - 1], 10);
+  }
   switch (quality) {
     case 'highest':
       format = formats[0];
@@ -140,10 +144,6 @@ exports.chooseFormat = (formats, options) => {
       break;
 
     case 'highestvideo':
-      function getBitrate(f) {
-        let s = f.bitrate.split('-');
-        return parseFloat(s[s.length - 1], 10);
-      }
       formats = exports.filterFormats(formats, 'video');
       format = null;
       for (let f of formats) {


### PR DESCRIPTION
React Native engine doesn't allow declaring functions in nested lexical scopes e.g. switches.
it throws `Strict mode does not allow function declarations in a lexically nested statement` error