### PR TITLE
Possible fix for ECONNRESET

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,9 @@ const ytdl = module.exports = function ytdl(link, options) {
       stream.emit('error', err);
       return;
     }
-
-    downloadFromInfoCallback(stream, info, options);
+    setImmediate(() => {
+      downloadFromInfoCallback(stream, info, options);
+    });
   });
 
   return stream;


### PR DESCRIPTION
Fixes #331 and Fixes #332

I noticed that honestly the biggest difference between downloadFromInfo and the main function is that downloadFromInfo uses `immediate` while the main function does not. I edited the main function to use setImmediate and I have yet to experience an ECONNRESET. Possible fix? It'd be awesome if I could get some more users to test this.