### PR TITLE
fix: added missing begin option from downloadOptions typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -11,6 +11,7 @@ declare module 'ytdl-core' {
         start?: number;
         end?: number;
       };
+      begin?: string; 
       requestOptions?: {};
       highWaterMark?: number;
       retries?: number;


### PR DESCRIPTION
Just a little fix for the TypeScript typings! 

The `begin` option isn't actually working for me when using it, but this helps remove some scary red underlines. 