### PR TITLE
Fix duplicate in typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -64,7 +64,6 @@ declare module 'ytdl-core' {
       ldpj?: string;
       videostats_playback_base_url?: string;
       innertube_context_client_version?: string;
-      player_response?: string;
       t?: string;
       fade_in_start_milliseconds: string;
       timestamp: string;


### PR DESCRIPTION
Remove a duplicate `player_response` in the `videoInfo` type.