### PR TITLE
Fixed type declarations

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,7 +4,7 @@ declare module 'ytdl-core' {
 
   namespace ytdl {
     type downloadOptions = {
-      quality?: 'lowest' | 'highest' | string | number;
+      quality?: 'lowest' | 'highest' | 'highestaudio' | 'lowestaudio' | 'highestvideo' | 'lowestvideo' | string | number;
       filter?: 'video' | 'videoonly' | 'audio' | 'audioonly' | ((format: videoFormat) => boolean);
       format?: videoFormat;
       range?: {


### PR DESCRIPTION
This was skimmed over for v0.29.0, and actually some X earlier release as well since it was also missing `highestaudio` and `highestvideo`. 

I haven't really looked into the rest to be honest so maybe there is more but for now at least this addresses #396 

Adding typings helps for IDE support, for example in IntelliJ / VSCode IntelliSense can suggest the proper values:

![image](https://user-images.githubusercontent.com/4019718/50857513-2b0bfb00-138e-11e9-9b2b-c90dc6488cb4.png)
