### PR TITLE
Added getVideoURLwithID 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Returns a video ID from a YouTube URL.
 
 Same as the above `ytdl.getURLVideoID()`, but can be called with the video ID directly, in which case it returns it. This is what ytdl uses internally.
 
+### ytdl.getVideoURLwithID(str) 
+
+Gets the video link from the YouTube video ID.
+
 ## Limitations
 
 ytdl cannot download videos that fall into the following

--- a/lib/util.js
+++ b/lib/util.js
@@ -289,7 +289,16 @@ exports.getURLVideoID = (link) => {
   }
   return id;
 };
-
+/**
+ * Gets the video link from the video ID just by concating two strings
+ *
+ * @param {string} str
+ * @return {string}
+ */
+exports.getVideoURLwithID = (str) => {
+  url = `https://www.youtube.com/watch?v=${str}`
+  return url;
+};
 
 /**
  * Gets video ID either from a url or by checking if the given string


### PR DESCRIPTION
Returns video link by only using the video id as the parameter.