### PR TITLE
Fix 403 forbidden error

### DIFF
--- a/lib/sig.js
+++ b/lib/sig.js
@@ -246,9 +246,9 @@ exports.setDownloadURL = (format, sig, debug) => {
     // into the parameter it specifies.
     // See https://github.com/fent/node-ytdl-core/issues/417
     if (format.sp) {
-        query[format.sp] = sig;
+      query[format.sp] = sig;
     } else {
-        query.signature = sig;
+      query.signature = sig;
     }
   }
 

--- a/lib/sig.js
+++ b/lib/sig.js
@@ -242,7 +242,14 @@ exports.setDownloadURL = (format, sig, debug) => {
   // See https://github.com/fent/node-ytdl-core/issues/127
   query.ratebypass = 'yes';
   if (sig) {
-    query.signature = sig;
+    // When YouTube provides a `sp` parameter the signature `sig` must go
+    // into the parameter it specifies.
+    // See https://github.com/fent/node-ytdl-core/issues/417
+    if (format.sp) {
+        query[format.sp] = sig;
+    } else {
+        query.signature = sig;
+    }
   }
 
   format.url = url.format(parsedUrl);


### PR DESCRIPTION
Fixes #417.

This error has been happening to me way too frequently, after I saw https://github.com/fent/node-ytdl-core/issues/417#issuecomment-468048467 from @omarroth I was able to fix this issue. So, thanks 👍 I wouldn't have had a clue how to fix this otherwise.

I tested this thoroughly and was able to confirm that this does indeed fix the 403 forbidden error.

I went ahead and added some comments also, please tell me if you'd prefer no comments.
There is a much more detailed explanation of the issue at https://github.com/ytdl-org/youtube-dl/pull/18927.