### PR TITLE
Itag 333 is 480p

### DIFF
--- a/lib/formats.js
+++ b/lib/formats.js
@@ -496,7 +496,7 @@ module.exports = {
 
   '333': {
     container: 'webm',
-    resolution: '240p HDR, HFR',
+    resolution: '480p HDR, HFR',
     encoding: 'VP9',
     profile: 'profile 2',
     bitrate: '0.5',


### PR DESCRIPTION
I found this error, backed by https://gist.github.com/sidneys/7095afe4da4ae58694d128b1034e01e2 and that format shows quality_label '480p60 HDR'. Check that gist to find other mismatches.