### PR TITLE
Fixed related videos returning empty array

### DIFF
--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -127,18 +127,18 @@ exports.getRelatedVideos = (body) => {
   let jsonStr = util.between(body, '\'RELATED_PLAYER_ARGS\': ', '\n');
   let watchNextJson;
   try {
-    jsonStr = jsonStr.substring(0, jsonStr.length - 1)
-    jsonStr = JSON.parse(jsonStr)
-    watchNextJson = JSON.parse(jsonStr.watch_next_response)
+    jsonStr = jsonStr.substring(0, jsonStr.length - 1);
+    jsonStr = JSON.parse(jsonStr);
+    watchNextJson = JSON.parse(jsonStr.watch_next_response);
   }
   catch (err) {
-    return []
+    return [];
   }
-  let secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results
+  let secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results;
   let recomendedVideos = [];
   for (let result of secondaryResults) {
     if (result.compactVideoRenderer) {
-      let details = result.compactVideoRenderer
+      let details = result.compactVideoRenderer;
       try {
         recomendedVideos.push({
           id: details.videoId,
@@ -149,10 +149,10 @@ exports.getRelatedVideos = (body) => {
           short_view_count_text: details.shortViewCountText.simpleText,
           view_count: details.viewCountText.simpleText.replace(' views', ''),
           length_seconds: details.lengthText.simpleText
-        })
+        });
       }
       catch (err) {}
     }
   }
-  return recomendedVideos
+  return recomendedVideos;
 }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -137,7 +137,7 @@ exports.getRelatedVideos = (body) => {
     return {
       id: util.between(e, 'id=', '&'),
       shortViewCount: util.between(e, 'short_view_count_text=', '+views')
-    }
+    };
   })
   let secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results;
   let recomendedVideos = [];
@@ -147,12 +147,12 @@ exports.getRelatedVideos = (body) => {
       try {
         let viewCount = details.viewCountText.simpleText;
         if(!viewCount)
-          viewCount = details.viewCountText.runs[0].text.replace(' watching','')
+          viewCount = details.viewCountText.runs[0].text.replace(' watching', '');
         let shortViewCount = details.shortViewCountText.simpleText;
         if(shortViewCount === 'Recommended for you')
         {
           if(shortViewCount = rvs_params.find((elem) => elem.id === details.videoId))
-            shortViewCount = shortViewCount.shortViewCount
+            shortViewCount = shortViewCount.shortViewCount;
         }
         recomendedVideos.push({
           id: details.videoId,
@@ -160,8 +160,8 @@ exports.getRelatedVideos = (body) => {
           author: details.shortBylineText.runs[0].text,
           ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
-          short_view_count_text: shortViewCount.replace(' views',''),
-          view_count: (viewCount !== 'Recommended for you') ? viewCount.replace(' views','') : shortViewCount.replace(' views',''),
+          short_view_count_text: shortViewCount.replace(' views', ''),
+          view_count: (viewCount !== 'Recommended for you') ? viewCount.replace(' views', '') : shortViewCount.replace(' views', ''),
           length_seconds: details.lengthText.simpleText
         });
       }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -138,7 +138,7 @@ exports.getRelatedVideos = (body) => {
       id: util.between(e, 'id=', '&'),
       shortViewCount: util.between(e, 'short_view_count_text=', '+views')
     };
-  })
+  });
   let secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results;
   let recomendedVideos = [];
   for (let result of secondaryResults) {

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -138,18 +138,18 @@ exports.getRelatedVideos = (body) => {
   let recomendedVideos = [];
   for (let result of secondaryResults) {
     if (result.compactVideoRenderer) {
-      let videoDetails = {};
       let details = result.compactVideoRenderer
       try {
-        videoDetails["id"] = details.videoId
-        videoDetails["title"] = details.title.simpleText
-        videoDetails["author"] = details.shortBylineText.runs[0].text
-        videoDetails["ucid"] = details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId
-        videoDetails["author_thumbnail"] = details.channelThumbnail.thumbnails[0].url
-        videoDetails["short_view_count_text"] = details.shortViewCountText.simpleText
-        videoDetails["view_count"] = details.viewCountText.simpleText.replace(" views", "")
-        videoDetails["length_seconds"] = details.lengthText.simpleText
-        recomendedVideos.push(videoDetails)
+        recomendedVideos.push({
+          "id": details.videoId,
+          "title": details.title.simpleText,
+          "author": details.shortBylineText.runs[0].text,
+          "ucid": details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
+          "author_thumbnail": details.channelThumbnail.thumbnails[0].url,
+          "short_view_count_text": details.shortViewCountText.simpleText,
+          "view_count": details.viewCountText.simpleText.replace(" views", ""),
+          "length_seconds": details.lengthText.simpleText
+        })
       }
       catch (err) {}
     }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -133,12 +133,7 @@ exports.getRelatedVideos = (body) => {
   catch (err) {
     return [];
   }
-  let rvsParams = jsonStr.rvs.split(',').map((e) => {
-    return {
-      id: util.between(e, 'id=', '&'),
-      shortViewCount: util.between(e, 'short_view_count_text=', '+views')
-    };
-  });
+  let rvsParams = jsonStr.rvs.split(',').map((e) => qs.parse(e));
   let secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results;
   let recomendedVideos = [];
   for (let result of secondaryResults) {
@@ -153,7 +148,7 @@ exports.getRelatedVideos = (body) => {
         if (!shortViewCount.match(/^\d/.test()) || !shortViewCount)
         {
           if (shortViewCount = rvsParams.find((elem) => elem.id === details.videoId)) {
-            shortViewCount = shortViewCount.shortViewCount;
+            shortViewCount = shortViewCount.short_view_count_text;
           }
         }
         recomendedVideos.push({

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -135,7 +135,7 @@ exports.getRelatedVideos = (body) => {
   }
   let rvsParams = jsonStr.rvs.split(',').map((e) => qs.parse(e));
   let secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results;
-  let recomendedVideos = [];
+  let videos = [];
   for (let result of secondaryResults) {
     let details = result.compactVideoRenderer;
     if (details) {
@@ -146,13 +146,13 @@ exports.getRelatedVideos = (body) => {
         }
         let shortViewCount = details.shortViewCountText.simpleText;
         let shortViewCountTest = /^\d/.test(shortViewCount);
-        if (!shortViewCountTest){
+        if (!shortViewCountTest) {
           let shortViewCountFromRVS = rvsParams.find((elem) => elem.id === details.videoId)
           if (shortViewCountFromRVS) {
             shortViewCount = shortViewCountFromRVS;
           }
         }
-        recomendedVideos.push({
+        videos.push({
           id: details.videoId,
           title: details.title.simpleText,
           author: details.shortBylineText.runs[0].text,
@@ -166,5 +166,5 @@ exports.getRelatedVideos = (body) => {
       catch (err) {}
     }
   }
-  return recomendedVideos;
+  return videos;
 }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -140,7 +140,7 @@ exports.getRelatedVideos = (body) => {
         videoDetails["id"] = result.videoId
         videoDetails["title"] = result.title.simpleText
         videoDetails["author"] = result.shortBylineText.runs[0].text
-        videoDetails["ucid"] = result.shortBylineText.runs[0].navigationEndpoint
+        videoDetails["ucid"] = result.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId
         videoDetails["author_thumbnail"] = result.channelThumbnail.thumbnails[0].url
         videoDetails["short_view_count_text"] = result.shortViewCountText.simpleText
         videoDetails["view_count"] = result.viewCountText.simpleText.replace(" views","") || 0

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -145,9 +145,8 @@ exports.getRelatedVideos = (body) => {
           viewCount = details.viewCountText.runs[0].text;
         }
         let shortViewCount = details.shortViewCountText.simpleText;
-        let shortViewCountTest = (/^\d/).test(shortViewCount);
-        if (!shortViewCountTest)
-        {
+        let shortViewCountTest = /^\d/.test(shortViewCount);
+        if (!shortViewCountTest){
           if (shortViewCount = rvsParams.find((elem) => elem.id === details.videoId)) {
             shortViewCount = shortViewCount.short_view_count_text;
           }
@@ -159,7 +158,7 @@ exports.getRelatedVideos = (body) => {
           ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
           short_view_count_text: shortViewCount.split(' ')[0],
-          view_count: ((/^\d/.test(viewCount)) ? viewCount : shortViewCount).split(' ')[0],
+          view_count: (/^\d/.test(viewCount) ? viewCount : shortViewCount).split(' ')[0],
           length_seconds: details.lengthText.simpleText
         });
       }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -146,13 +146,15 @@ exports.getRelatedVideos = (body) => {
     if (details) {
       try {
         let viewCount = details.viewCountText.simpleText;
-        if (!viewCount)
+        if (!viewCount) {
           viewCount = details.viewCountText.runs[0].text.replace(' watching', '');
+        }
         let shortViewCount = details.shortViewCountText.simpleText;
         if (!shortViewCount.match(/^\d/.test()) || !shortViewCount)
         {
-          if (shortViewCount = rvsParams.find((elem) => elem.id === details.videoId))
+          if (shortViewCount = rvsParams.find((elem) => elem.id === details.videoId)) {
             shortViewCount = shortViewCount.shortViewCount;
+          }
         }
         recomendedVideos.push({
           id: details.videoId,

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -124,11 +124,32 @@ exports.getPublished = (body) => {
  * @return {Array.<Object>}
  */
 exports.getRelatedVideos = (body) => {
-  let jsonStr = util.between(body, '\'RELATED_PLAYER_ARGS\': {"rvs":', '},');
+  let jsonStr = util.between(body, '\'RELATED_PLAYER_ARGS\': ','\n');
   try {
-    jsonStr = JSON.parse(jsonStr);
+    jsonStr = jsonStr.substring(0,jsonStr.length-1);
+    jsonStr = JSON.parse(jsonStr)
+    watch_next_json = JSON.parse(jsonStr["watch_next_response"])
+    secondary_results = watch_next_json.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results
+    recomendedVideos = [];
+    for(i in secondary_results)
+    {
+      let videoDetails = {};
+      if(secondary_results[i].compactVideoRenderer !== undefined)
+      {
+        let result = secondary_results[i].compactVideoRenderer
+        videoDetails["id"] = result.videoId
+        videoDetails["title"] = result.title.simpleText
+        videoDetails["author"] = result.shortBylineText.runs[0].text
+        videoDetails["ucid"] = result.shortBylineText.runs[0].navigationEndpoint
+        videoDetails["author_thumbnail"] = result.channelThumbnail.thumbnails[0].url
+        videoDetails["short_view_count_text"] = result.shortViewCountText.simpleText
+        videoDetails["view_count"] = result.viewCountText.simpleText.replace(" views","") || 0
+        videoDetails["length_seconds"] = result.lengthText.simpleText || "0.00"
+        recomendedVideos.push(videoDetails)
+      }
+    }
+    return recomendedVideos
   } catch (err) {
     return [];
   }
-  return jsonStr.split(',').map((link) => qs.parse(link));
 };

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -145,8 +145,9 @@ exports.getRelatedVideos = (body) => {
           viewCount = details.viewCountText.runs[0].text.split(' ')[0];
         }
         let shortViewCount = details.shortViewCountText.simpleText;
-        if (!shortViewCount.match(/^\d/.test()) || !shortViewCount)
+        if (!(/^\d/).test(shortViewCount) || !shortViewCount)
         {
+          console.log(shortViewCount)
           if (shortViewCount = rvsParams.find((elem) => elem.id === details.videoId)) {
             shortViewCount = shortViewCount.short_view_count_text;
           }
@@ -158,7 +159,7 @@ exports.getRelatedVideos = (body) => {
           ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
           short_view_count_text: shortViewCount.split(' ')[0],
-          view_count: viewCount.match(/^\d/.test()) ? viewCount.split(' ')[0] : shortViewCount.split(' ')[0],
+          view_count: (viewCount.match(/^\d/.test()) ? viewCount : shortViewCount).split(' ')[0],
           length_seconds: details.lengthText.simpleText
         });
       }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -133,20 +133,35 @@ exports.getRelatedVideos = (body) => {
   catch (err) {
     return [];
   }
+  let rvs_params = jsonStr.rvs.split(',').map((e) => {
+    return {
+      id: util.between(e, 'id=', '&'),
+      shortViewCount: util.between(e, 'short_view_count_text=', '+views')
+    }
+  })
   let secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results;
   let recomendedVideos = [];
   for (let result of secondaryResults) {
-    if (result.compactVideoRenderer) {
-      let details = result.compactVideoRenderer;
+    let details;
+    if (details = result.compactVideoRenderer) {
       try {
+        let viewCount = details.viewCountText.simpleText;
+        if(!viewCount)
+          viewCount = details.viewCountText.runs[0].text.replace(' watching','')
+        let shortViewCount = details.shortViewCountText.simpleText;
+        if(shortViewCount === 'Recommended for you')
+        {
+          if(shortViewCount = rvs_params.find((elem) => elem.id === details.videoId))
+            shortViewCount = shortViewCount.shortViewCount
+        }
         recomendedVideos.push({
           id: details.videoId,
           title: details.title.simpleText,
           author: details.shortBylineText.runs[0].text,
           ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
-          short_view_count_text: details.shortViewCountText.simpleText,
-          view_count: details.viewCountText.simpleText.replace(' views', ''),
+          short_view_count_text: shortViewCount.replace(' views',''),
+          view_count: (viewCount !== 'Recommended for you') ? viewCount.replace(' views','') : shortViewCount.replace(' views',''),
           length_seconds: details.lengthText.simpleText
         });
       }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -142,7 +142,7 @@ exports.getRelatedVideos = (body) => {
       try {
         let viewCount = details.viewCountText.simpleText;
         if (!viewCount) {
-          viewCount = details.viewCountText.runs[0].text.replace(' watching', '');
+          viewCount = details.viewCountText.runs[0].text.split(' ')[0];
         }
         let shortViewCount = details.shortViewCountText.simpleText;
         if (!shortViewCount.match(/^\d/.test()) || !shortViewCount)

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -143,8 +143,8 @@ exports.getRelatedVideos = (body) => {
         videoDetails["ucid"] = result.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId
         videoDetails["author_thumbnail"] = result.channelThumbnail.thumbnails[0].url
         videoDetails["short_view_count_text"] = result.shortViewCountText.simpleText
-        videoDetails["view_count"] = result.viewCountText.simpleText.replace(" views","") || 0
-        videoDetails["length_seconds"] = result.lengthText.simpleText || "0.00"
+        videoDetails["view_count"] = result.viewCountText.simpleText.replace(" views","")
+        videoDetails["length_seconds"] = result.lengthText.simpleText
         recomendedVideos.push(videoDetails)
       }
     }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -1,7 +1,7 @@
-const qs       = require('querystring');
-const url      = require('url');
+const qs = require('querystring');
+const url = require('url');
 const Entities = require('html-entities').AllHtmlEntities;
-const util     = require('./util');
+const util = require('./util');
 
 
 const VIDEO_URL = 'https://www.youtube.com/watch?v=';
@@ -124,32 +124,37 @@ exports.getPublished = (body) => {
  * @return {Array.<Object>}
  */
 exports.getRelatedVideos = (body) => {
-  let jsonStr = util.between(body, '\'RELATED_PLAYER_ARGS\': ','\n');
+  let jsonStr = util.between(body, '\'RELATED_PLAYER_ARGS\': ', '\n');
+  let watchNextJson;
   try {
-    jsonStr = jsonStr.substring(0,jsonStr.length-1);
+    jsonStr = jsonStr.substring(0, jsonStr.length - 1)
     jsonStr = JSON.parse(jsonStr)
-    watch_next_json = JSON.parse(jsonStr["watch_next_response"])
-    secondary_results = watch_next_json.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results
-    recomendedVideos = [];
-    for(i in secondary_results)
-    {
+    watchNextJson = JSON.parse(jsonStr["watch_next_response"])
+  }
+  catch (err) {
+    return []
+  }
+  let secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results
+  let recomendedVideos = [];
+  for (let result of secondaryResults) {
+    if (result.compactVideoRenderer !== undefined) {
       let videoDetails = {};
-      if(secondary_results[i].compactVideoRenderer !== undefined)
-      {
-        let result = secondary_results[i].compactVideoRenderer
-        videoDetails["id"] = result.videoId
-        videoDetails["title"] = result.title.simpleText
-        videoDetails["author"] = result.shortBylineText.runs[0].text
-        videoDetails["ucid"] = result.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId
-        videoDetails["author_thumbnail"] = result.channelThumbnail.thumbnails[0].url
-        videoDetails["short_view_count_text"] = result.shortViewCountText.simpleText
-        videoDetails["view_count"] = result.viewCountText.simpleText.replace(" views","")
-        videoDetails["length_seconds"] = result.lengthText.simpleText
+      let details = result.compactVideoRenderer
+      try {
+        videoDetails["id"] = details.videoId
+        videoDetails["title"] = details.title.simpleText
+        videoDetails["author"] = details.shortBylineText.runs[0].text
+        videoDetails["ucid"] = details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId
+        videoDetails["author_thumbnail"] = details.channelThumbnail.thumbnails[0].url
+        videoDetails["short_view_count_text"] = details.shortViewCountText.simpleText
+        videoDetails["view_count"] = details.viewCountText.simpleText.replace(" views", "")
+        videoDetails["length_seconds"] = details.lengthText.simpleText
         recomendedVideos.push(videoDetails)
       }
+      catch (err) {
+
+      }
     }
-    return recomendedVideos
-  } catch (err) {
-    return [];
   }
-};
+  return recomendedVideos
+}

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -137,7 +137,7 @@ exports.getRelatedVideos = (body) => {
   let secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results
   let recomendedVideos = [];
   for (let result of secondaryResults) {
-    if (result.compactVideoRenderer !== undefined) {
+    if (result.compactVideoRenderer) {
       let videoDetails = {};
       let details = result.compactVideoRenderer
       try {
@@ -151,9 +151,7 @@ exports.getRelatedVideos = (body) => {
         videoDetails["length_seconds"] = details.lengthText.simpleText
         recomendedVideos.push(videoDetails)
       }
-      catch (err) {
-
-      }
+      catch (err) {}
     }
   }
   return recomendedVideos

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -142,7 +142,7 @@ exports.getRelatedVideos = (body) => {
       try {
         let viewCount = details.viewCountText.simpleText;
         if (!viewCount) {
-          viewCount = details.viewCountText.runs[0].text.split(' ')[0];
+          viewCount = details.viewCountText.runs[0].text;
         }
         let shortViewCount = details.shortViewCountText.simpleText;
         let shortViewCountTest = (/^\d/).test(shortViewCount);

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -133,7 +133,7 @@ exports.getRelatedVideos = (body) => {
   catch (err) {
     return [];
   }
-  let rvs_params = jsonStr.rvs.split(',').map((e) => {
+  let rvsParams = jsonStr.rvs.split(',').map((e) => {
     return {
       id: util.between(e, 'id=', '&'),
       shortViewCount: util.between(e, 'short_view_count_text=', '+views')
@@ -151,7 +151,7 @@ exports.getRelatedVideos = (body) => {
         let shortViewCount = details.shortViewCountText.simpleText;
         if(shortViewCount === 'Recommended for you')
         {
-          if(shortViewCount = rvs_params.find((elem) => elem.id === details.videoId))
+          if(shortViewCount = rvsParams.find((elem) => elem.id === details.videoId))
             shortViewCount = shortViewCount.shortViewCount;
         }
         recomendedVideos.push({

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -146,12 +146,12 @@ exports.getRelatedVideos = (body) => {
     if (details) {
       try {
         let viewCount = details.viewCountText.simpleText;
-        if(!viewCount)
+        if (!viewCount)
           viewCount = details.viewCountText.runs[0].text.replace(' watching', '');
         let shortViewCount = details.shortViewCountText.simpleText;
-        if(!shortViewCount.match(/^\d/) || !shortViewCount)
+        if (!shortViewCount.match(/^\d/) || !shortViewCount)
         {
-          if(shortViewCount = rvsParams.find((elem) => elem.id === details.videoId))
+          if (shortViewCount = rvsParams.find((elem) => elem.id === details.videoId))
             shortViewCount = shortViewCount.shortViewCount;
         }
         recomendedVideos.push({

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -145,9 +145,9 @@ exports.getRelatedVideos = (body) => {
           viewCount = details.viewCountText.runs[0].text.split(' ')[0];
         }
         let shortViewCount = details.shortViewCountText.simpleText;
-        if (!(/^\d/).test(shortViewCount) || !shortViewCount)
+        let shortViewCountTest = (/^\d/).test(shortViewCount);
+        if (!shortViewCountTest)
         {
-          console.log(shortViewCount)
           if (shortViewCount = rvsParams.find((elem) => elem.id === details.videoId)) {
             shortViewCount = shortViewCount.short_view_count_text;
           }
@@ -159,7 +159,7 @@ exports.getRelatedVideos = (body) => {
           ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
           short_view_count_text: shortViewCount.split(' ')[0],
-          view_count: (viewCount.match(/^\d/.test()) ? viewCount : shortViewCount).split(' ')[0],
+          view_count: ((/^\d/.test(viewCount)) ? viewCount : shortViewCount).split(' ')[0],
           length_seconds: details.lengthText.simpleText
         });
       }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -149,7 +149,7 @@ exports.getRelatedVideos = (body) => {
         if(!viewCount)
           viewCount = details.viewCountText.runs[0].text.replace(' watching', '');
         let shortViewCount = details.shortViewCountText.simpleText;
-        if(shortViewCount === 'Recommended for you')
+        if(!shortViewCount.match(/^\d/) || !shortViewCount)
         {
           if(shortViewCount = rvsParams.find((elem) => elem.id === details.videoId))
             shortViewCount = shortViewCount.shortViewCount;
@@ -161,7 +161,7 @@ exports.getRelatedVideos = (body) => {
           ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
           short_view_count_text: shortViewCount.replace(' views', ''),
-          view_count: (viewCount !== 'Recommended for you') ? viewCount.replace(' views', '') : shortViewCount.replace(' views', ''),
+          view_count: (viewCount.match(/^\d/)) ? viewCount.replace(' views','') : shortViewCount.replace(' views',''),
           length_seconds: details.lengthText.simpleText
         });
       }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -141,14 +141,14 @@ exports.getRelatedVideos = (body) => {
       let details = result.compactVideoRenderer
       try {
         recomendedVideos.push({
-          "id": details.videoId,
-          "title": details.title.simpleText,
-          "author": details.shortBylineText.runs[0].text,
-          "ucid": details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
-          "author_thumbnail": details.channelThumbnail.thumbnails[0].url,
-          "short_view_count_text": details.shortViewCountText.simpleText,
-          "view_count": details.viewCountText.simpleText.replace(" views", ""),
-          "length_seconds": details.lengthText.simpleText
+          id: details.videoId,
+          title: details.title.simpleText,
+          author: details.shortBylineText.runs[0].text,
+          ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
+          author_thumbnail: details.channelThumbnail.thumbnails[0].url,
+          short_view_count_text: details.shortViewCountText.simpleText,
+          view_count: details.viewCountText.simpleText.replace(' views', ''),
+          length_seconds: details.lengthText.simpleText
         })
       }
       catch (err) {}

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -1,7 +1,7 @@
-const qs = require('querystring');
-const url = require('url');
+const qs       = require('querystring');
+const url      = require('url');
 const Entities = require('html-entities').AllHtmlEntities;
-const util = require('./util');
+const util     = require('./util');
 
 
 const VIDEO_URL = 'https://www.youtube.com/watch?v=';
@@ -129,7 +129,7 @@ exports.getRelatedVideos = (body) => {
   try {
     jsonStr = jsonStr.substring(0, jsonStr.length - 1)
     jsonStr = JSON.parse(jsonStr)
-    watchNextJson = JSON.parse(jsonStr["watch_next_response"])
+    watchNextJson = JSON.parse(jsonStr.watch_next_response)
   }
   catch (err) {
     return []

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -142,8 +142,8 @@ exports.getRelatedVideos = (body) => {
   let secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results;
   let recomendedVideos = [];
   for (let result of secondaryResults) {
-    let details;
-    if (details = result.compactVideoRenderer) {
+    let details = result.compactVideoRenderer;
+    if (details) {
       try {
         let viewCount = details.viewCountText.simpleText;
         if(!viewCount)

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -124,10 +124,9 @@ exports.getPublished = (body) => {
  * @return {Array.<Object>}
  */
 exports.getRelatedVideos = (body) => {
-  let jsonStr = util.between(body, '\'RELATED_PLAYER_ARGS\': ', '\n');
+  let jsonStr = util.between(body, '\'RELATED_PLAYER_ARGS\': ', ',\n');
   let watchNextJson;
   try {
-    jsonStr = jsonStr.substring(0, jsonStr.length - 1);
     jsonStr = JSON.parse(jsonStr);
     watchNextJson = JSON.parse(jsonStr.watch_next_response);
   }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -152,6 +152,8 @@ exports.getRelatedVideos = (body) => {
             shortViewCount = shortViewCountFromRVS;
           }
         }
+        viewCount = (/^\d/.test(viewCount) ? viewCount : shortViewCount).split(' ')[0]; 
+        let lengthSeconds = parseTime.humanStr(details.lengthText.simpleText);
         videos.push({
           id: details.videoId,
           title: details.title.simpleText,
@@ -159,8 +161,8 @@ exports.getRelatedVideos = (body) => {
           ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
           short_view_count_text: shortViewCount.split(' ')[0],
-          view_count: (/^\d/.test(viewCount) ? viewCount : shortViewCount).split(' ')[0],
-          length_seconds: details.lengthText.simpleText
+          view_count: viewCount.replace(',',''),
+          length_seconds: Math.floor(lengthSeconds/1000)
         });
       }
       catch (err) {}

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -149,7 +149,7 @@ exports.getRelatedVideos = (body) => {
         if (!viewCount)
           viewCount = details.viewCountText.runs[0].text.replace(' watching', '');
         let shortViewCount = details.shortViewCountText.simpleText;
-        if (!shortViewCount.match(/^\d/) || !shortViewCount)
+        if (!shortViewCount.match(/^\d/.test()) || !shortViewCount)
         {
           if (shortViewCount = rvsParams.find((elem) => elem.id === details.videoId))
             shortViewCount = shortViewCount.shortViewCount;
@@ -160,8 +160,8 @@ exports.getRelatedVideos = (body) => {
           author: details.shortBylineText.runs[0].text,
           ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
-          short_view_count_text: shortViewCount.replace(' views', ''),
-          view_count: (viewCount.match(/^\d/)) ? viewCount.replace(' views','') : shortViewCount.replace(' views',''),
+          short_view_count_text: shortViewCount.split(' ')[0],
+          view_count: viewCount.match(/^\d/.test()) ? viewCount.split(' ')[0] : shortViewCount.split(' ')[0],
           length_seconds: details.lengthText.simpleText
         });
       }

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -1,7 +1,9 @@
-const qs       = require('querystring');
-const url      = require('url');
-const Entities = require('html-entities').AllHtmlEntities;
-const util     = require('./util');
+const qs          = require('querystring');
+const url         = require('url');
+const Entities    = require('html-entities').AllHtmlEntities;
+const util        = require('./util');
+const parseTime   = require('m3u8stream/lib/parse-time');
+
 
 
 const VIDEO_URL = 'https://www.youtube.com/watch?v=';
@@ -152,8 +154,7 @@ exports.getRelatedVideos = (body) => {
             shortViewCount = shortViewCountFromRVS;
           }
         }
-        viewCount = (/^\d/.test(viewCount) ? viewCount : shortViewCount).split(' ')[0]; 
-        let lengthSeconds = parseTime.humanStr(details.lengthText.simpleText);
+        viewCount = (/^\d/.test(viewCount) ? viewCount : shortViewCount).split(' ')[0];
         videos.push({
           id: details.videoId,
           title: details.title.simpleText,
@@ -161,8 +162,9 @@ exports.getRelatedVideos = (body) => {
           ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
           short_view_count_text: shortViewCount.split(' ')[0],
-          view_count: viewCount.replace(',',''),
-          length_seconds: Math.floor(lengthSeconds/1000)
+          short_view_count: parseTime.durationStr(shortViewCount.split(' ')[0]),
+          view_count: viewCount.replace(',', ''),
+          length_seconds: Math.floor(parseTime.humanStr(details.lengthText.simpleText) / 1000)
         });
       }
       catch (err) {}

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -149,7 +149,7 @@ exports.getRelatedVideos = (body) => {
         let shortViewCount = details.shortViewCountText.simpleText;
         let shortViewCountTest = /^\d/.test(shortViewCount);
         if (!shortViewCountTest) {
-          let shortViewCountFromRVS = rvsParams.find((elem) => elem.id === details.videoId)
+          let shortViewCountFromRVS = rvsParams.find((elem) => elem.id === details.videoId);
           if (shortViewCountFromRVS) {
             shortViewCount = shortViewCountFromRVS;
           }
@@ -162,7 +162,6 @@ exports.getRelatedVideos = (body) => {
           ucid: details.shortBylineText.runs[0].navigationEndpoint.browseEndpoint.browseId,
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
           short_view_count_text: shortViewCount.split(' ')[0],
-          short_view_count: parseTime.durationStr(shortViewCount.split(' ')[0]),
           view_count: viewCount.replace(',', ''),
           length_seconds: Math.floor(parseTime.humanStr(details.lengthText.simpleText) / 1000)
         });

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -147,8 +147,9 @@ exports.getRelatedVideos = (body) => {
         let shortViewCount = details.shortViewCountText.simpleText;
         let shortViewCountTest = /^\d/.test(shortViewCount);
         if (!shortViewCountTest){
-          if (shortViewCount = rvsParams.find((elem) => elem.id === details.videoId)) {
-            shortViewCount = shortViewCount.short_view_count_text;
+          let shortViewCountFromRVS = rvsParams.find((elem) => elem.id === details.videoId)
+          if (shortViewCountFromRVS) {
+            shortViewCount = shortViewCountFromRVS;
           }
         }
         recomendedVideos.push({


### PR DESCRIPTION
Fixes #479 
Before
![Screenshot 2019-08-30 at 11 53 18 PM](https://user-images.githubusercontent.com/10515204/64043696-b25ae880-cb82-11e9-8dd1-05d6c6386463.png)
After
![Screenshot 2019-08-30 at 11 53 48 PM](https://user-images.githubusercontent.com/10515204/64043705-b71f9c80-cb82-11e9-8919-d0a082fa3dc1.png)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#479: related_videos is always empty](https://issuehunt.io/repos/21333232/issues/479)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->