### PR TITLE
fix: add Error callback when fails to parse 'videoDetails'

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -179,7 +179,7 @@ const gotConfig = (id, options, additional, config, fromEmbed, callback) => {
       info.fmt_list.map((format) => format.split('/')) : [];
 
     info.formats = parseFormats(info);
-      // Add additional properties to info.
+    // Add additional properties to info.
     Object.assign(info, additional, {
       video_id: id,
 
@@ -187,7 +187,7 @@ const gotConfig = (id, options, additional, config, fromEmbed, callback) => {
       video_url: VIDEO_URL + id,
 
       // Copy over a few props from `player_response.videoDetails`
-      // for bakcwards compatibility.
+      // for backwards compatibility.
       title: info.player_response.videoDetails && info.player_response.videoDetails.title,
       length_seconds: info.player_response.videoDetails && info.player_response.videoDetails.lengthSeconds,
     });

--- a/lib/info.js
+++ b/lib/info.js
@@ -179,19 +179,23 @@ const gotConfig = (id, options, additional, config, fromEmbed, callback) => {
       info.fmt_list.map((format) => format.split('/')) : [];
 
     info.formats = parseFormats(info);
+    try {
+      // Add additional properties to info.
+      Object.assign(info, additional, {
+        video_id: id,
 
-    // Add additional properties to info.
-    Object.assign(info, additional, {
-      video_id: id,
+        // Give the standard link to the video.
+        video_url: VIDEO_URL + id,
 
-      // Give the standard link to the video.
-      video_url: VIDEO_URL + id,
+        // Copy over a few props from `player_response.videoDetails`
+        // for bakcwards compatibility.
+        title: info.player_response.videoDetails.title,
+        length_seconds: info.player_response.videoDetails.lengthSeconds,
+      });
+    } catch (e) {
+      return callback(Error(`Error parsing "videoDetails": ${e.message}`))
+    }
 
-      // Copy over a few props from `player_response.videoDetails`
-      // for bakcwards compatibility.
-      title: info.player_response.videoDetails.title,
-      length_seconds: info.player_response.videoDetails.lengthSeconds,
-    });
     info.age_restricted = fromEmbed;
     info.html5player = config.assets.js;
 

--- a/lib/info.js
+++ b/lib/info.js
@@ -179,22 +179,18 @@ const gotConfig = (id, options, additional, config, fromEmbed, callback) => {
       info.fmt_list.map((format) => format.split('/')) : [];
 
     info.formats = parseFormats(info);
-    try {
       // Add additional properties to info.
-      Object.assign(info, additional, {
-        video_id: id,
+    Object.assign(info, additional, {
+      video_id: id,
 
-        // Give the standard link to the video.
-        video_url: VIDEO_URL + id,
+      // Give the standard link to the video.
+      video_url: VIDEO_URL + id,
 
-        // Copy over a few props from `player_response.videoDetails`
-        // for bakcwards compatibility.
-        title: info.player_response.videoDetails.title,
-        length_seconds: info.player_response.videoDetails.lengthSeconds,
-      });
-    } catch (e) {
-      return callback(Error(`Error parsing "videoDetails": ${e.message}`))
-    }
+      // Copy over a few props from `player_response.videoDetails`
+      // for bakcwards compatibility.
+      title: info.player_response.videoDetails && info.player_response.videoDetails.title,
+      length_seconds: info.player_response.videoDetails && info.player_response.videoDetails.lengthSeconds,
+    });
 
     info.age_restricted = fromEmbed;
     info.html5player = config.assets.js;


### PR DESCRIPTION
resolves #477

## As is
ytdl-core crashes when youtube video is private.
If youtube video is private, there is no `videoDetails` key in `player_response`.
Therefore, an error occurs and is returned when you attempt to read the `.title` or `.lengthSeconds` property.
https://github.com/fent/node-ytdl-core/blob/0c5927c540499bfc2a59b9a5364dbace47dce57e/lib/info.js#L184-L194


## To be
I added `try{} catch(e) {}` to prevent the return of unhandled error while parsing videoDetails.
