### PR TITLE
Fixed and expanded the proxy examples

### DIFF
--- a/example/http_proxy_with_auth.js
+++ b/example/http_proxy_with_auth.js
@@ -1,0 +1,30 @@
+const ytdl = require('..');
+const proxyDetails = { ip: '111.111.111.111', port: 8080, username: 'hadorons', password: 'pass1234' }
+const auth = Buffer.from(`${proxyDetails.username}:${proxyDetails.password}`).toString('base64');
+
+const stream = ytdl('https://www.youtube.com/watch?v=2UBFIhS1YBk', {
+  requestOptions: {
+    transform: (parsed) => {
+      return {
+        host: proxyDetails.ip,
+        port: proxyDetails.port,
+        path: parsed.href,
+        headers: {
+          Host: parsed.host,
+          'Proxy-Authorization': 'Basic ' + auth // Remove it if you don't need to authenticate to your proxy.
+        },
+        protocol: 'http:', // This is needed if you want to communicate with your proxy over HTTP and not HTTPS
+      };
+    }
+  },
+});
+
+console.log('Starting Download');
+
+stream.on('data', (chunk) => {
+  console.log('downloaded ', chunk.length);
+});
+
+stream.on('end', () => {
+  console.log('Finished');
+});

--- a/example/proxy.js
+++ b/example/proxy.js
@@ -6,7 +6,7 @@ const stream = ytdl('https://www.youtube.com/watch?v=2UBFIhS1YBk', {
       return {
         host: '127.0.0.1',
         port: 8888,
-        path: '/' + parsed.href,
+        path: parsed.href,
         headers: { Host: parsed.host },
       };
     },


### PR DESCRIPTION
I wasted a lot of time figuring out why my code doesn't work, I also found couple of issues of people trying to understand why their code doesn't work either, this should solve it for future visitors.

What's included:

- The path was broken in the example.
- Added another example of http proxy for HTTPS website (YouTube) which is most common.
- Added in the example authentication to the proxy