### PR TITLE
test: fix test not passing because of private video

### DIFF
--- a/test/irl-test.js
+++ b/test/irl-test.js
@@ -9,7 +9,6 @@ let videos = {
   'VEVO 2'                  : 'pJk0p-98Xzc',
   'Age restricted VEVO'     : 'B3eAMGXFw1o',
   'Age restricted'          : 'BlhyROz85OU',
-  'Age restricted 2'        : 'Tzuvfy4jFwE',
   'Embed domain restricted' : 'B3eAMGXFw1o',
   'No embed allowed'        : 'GFg8BP01F5Q',
   'Offensive'               : 'hCKDsjLt_qU',


### PR DESCRIPTION
Removed the IRL test on video `Tzuvfy4jFwE` because it has become private.

Sorry for spamming but my other PR's tests are not passing because of this.
It should also fix greenkeeper's issues #497, #491, #492 .