### PR TITLE
Fix secondaryResults not iterable

### DIFF
--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -117,6 +117,12 @@ exports.getPublished = (body) => {
   return Date.parse(getMetaItem(body, 'datePublished'));
 };
 
+function isIterable(obj) {
+  if (obj == null) {
+    return false;
+  }
+  return typeof obj[Symbol.iterator] === 'function';
+}
 
 /**
  * Get video published at from html.
@@ -133,6 +139,10 @@ exports.getRelatedVideos = (body) => {
     watchNextJson = JSON.parse(jsonStr.watch_next_response);
     rvsParams = jsonStr.rvs.split(',').map((e) => qs.parse(e));
     secondaryResults = watchNextJson.contents.twoColumnWatchNextResults.secondaryResults.secondaryResults.results;
+
+    if (!isIterable(secondaryResults)) {
+      return [];
+    }
   }
   catch (err) {
     return [];
@@ -157,7 +167,7 @@ exports.getRelatedVideos = (body) => {
           author_thumbnail: details.channelThumbnail.thumbnails[0].url,
           short_view_count_text: shortViewCount.split(' ')[0],
           view_count: viewCount.replace(',', ''),
-          length_seconds:  details.lengthText ?
+          length_seconds: details.lengthText ?
             Math.floor(parseTime.humanStr(details.lengthText.simpleText) / 1000) :
             rvsParams && rvsParams.length_seconds + '',
           video_thumbnail: details.thumbnail.thumbnails[0].url,


### PR DESCRIPTION
I'm seeing this exception quite a lot in my logs, not sure in which scenarios it happens, but often times `secondaryResults` isn't actually an array.

```
/home/me_app/app/node_modules/ytdl-core/lib/info-extras.js:141
  for (let result of secondaryResults) {
                     ^

TypeError: secondaryResults is not iterable
    at Object.exports.getRelatedVideos (/home/me_app/app/node_modules/ytdl-core/lib/info-extras.js:141:22)
    at request (/home/me_app/app/node_modules/ytdl-core/lib/info.js:72:30)
    at PassThrough.stream.on (/home/me_app/app/node_modules/miniget/lib/index.js:195:30)
    at PassThrough.emit (events.js:198:13)
    at PassThrough.EventEmitter.emit (domain.js:448:20)
    at endReadableNT (_stream_readable.js:1143:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```