### PR TITLE
Fix getRelatedVideos() by changing util.between() to use regex

### DIFF
--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -126,7 +126,7 @@ exports.getPublished = (body) => {
  * @return {Array.<Object>}
  */
 exports.getRelatedVideos = (body) => {
-  let jsonStr = util.between(body, '\'RELATED_PLAYER_ARGS\': ', ',\n');
+  let jsonStr = util.between(body, '\'RELATED_PLAYER_ARGS\': ', /,[\n\r]/);
   let watchNextJson, rvsParams, secondaryResults;
   try {
     jsonStr = JSON.parse(jsonStr);

--- a/lib/util.js
+++ b/lib/util.js
@@ -343,7 +343,7 @@ exports.addFormatMeta = (format) => {
  */
 exports.stripHTML = (html) => {
   return html
-    .replace(/\n/g, ' ')
+    .replace(/[\n\r]/g, ' ')
     .replace(/\s*<\s*br\s*\/?\s*>\s*/gi, '\n')
     .replace(/<\s*\/\s*p\s*>\s*<\s*p[^>]*>/gi, '\n')
     .replace(/<.*?>/gi, '')


### PR DESCRIPTION
On windows the line breaks are a little weird, sometimes windows changes `\n` to `\r`, so to accommodate for that I changed the second argument for `util.between()` to use regex that tests for either of the two breaks.
By doing that all of the tests are now passing.

Fixes #577 