### PR TITLE
Typings: videoFormat.audioBitrate / .quality / .qualityLabel

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -24,14 +24,15 @@ declare module 'ytdl-core' {
       url: string;
       mimeType?: string;
       bitrate?: number | string;
+      audioBitrate?: number;
       width?: number;
       height?: number;
       initRange?: { start: string; end: string };
       indexRange?: { start: string; end: string };
       lastModified: string;
       contentLength: string;
-      quality: 'tiny' | 'small' | 'medium' | 'large' | 'hd720' | 'hd1080' | 'hd1440' | string;
-      qualityLabel: '144p' | '240p' | '270p' | '360p' | '480p' | '720p' | '1080p' | '1440p' | '2160p' | '4320p';
+      quality: 'tiny' | 'small' | 'medium' | 'large' | 'hd720' | 'hd1080' | 'hd1440' | 'hd2160' | 'highres' | string;
+      qualityLabel: '144p' | '144p 15fps' | '144p60 HDR' | '240p' | '240p60 HDR' | '270p' | '360p' | '360p60 HDR' | '480p' | '480p60 HDR' | '720p' | '720p60' | '720p60 HDR' | '1080p' | '1080p60' | '1080p60 HDR' | '1440p' | '1440p60' | '1440p60 HDR' | '2160p' | '2160p60' | '2160p60 HDR' | '4320p' | '4320p60';
       projectionType: 'RECTANGULAR';
       fps?: number;
       averageBitrate: number;


### PR DESCRIPTION
- added: `videoFormat.audioBitrate`
- expanded: `videoFormat.quality` ("hd2160", "highres")
- expanded: `videoFormat.qualityLabel` ("144p 15fps", "144p60 HDR", "240p60 HDR", "360p60 HDR", "480p60 HDR", "720p60", "720p60 HDR", "1080p60", "1080p60 HDR", "1440p60", "1440p60 HDR", "2160p60", "2160p60 HDR", "4320p60")