### PR TITLE
change lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   eslint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,3 +10,4 @@ jobs:
       - uses: Krizzu/eslint-check-action@v1.1.0
         with:
           ghToken: ${{ secrets.GITHUB_TOKEN }}
+          eslintConfig: .eslintrc.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,4 +10,3 @@ jobs:
       - uses: a-b-r-o-w-n/eslint-action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          files: "lib/*, test/*"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: Krizzu/eslint-check-action@v1.1.0
+      - uses: a-b-r-o-w-n/eslint-action@v1
         with:
-          ghToken: ${{ secrets.GITHUB_TOKEN }}
-          eslintConfig: .eslintrc.json
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: hallee/eslint-action@master
+      - uses: Krizzu/eslint-check-action@v1.1.0
         with:
-          repo-token: ${{secrets.GITHUB_TOKEN}}
+          ghToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: hallee/eslint-action@master
+      - uses: a-b-r-o-w-n/eslint-action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,18 @@ on: [push, pull_request]
 
 jobs:
   eslint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: a-b-r-o-w-n/eslint-action@v1
+
+      - uses: actions/setup-node@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          node-version: 13.x
+
+      - name: npm install, build, and lint
+        run: |
+          npm install
+          npm run build --if-present
+          npm run-script lint
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: a-b-r-o-w-n/eslint-action@v1
+      - uses: hallee/eslint-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,3 +10,4 @@ jobs:
       - uses: a-b-r-o-w-n/eslint-action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          files: "lib/*, test/*"

--- a/example/proxy.js
+++ b/example/proxy.js
@@ -5,7 +5,7 @@ const agent = HttpsProxyAgent({
   ip: '111.111.111.111',
   port: 8080,
   // Remove this if you don't need to authenticate to your proxy.
-  auth: 'user:pass'
+  auth: 'user:pass',
 });
 
 const stream = ytdl('https://www.youtube.com/watch?v=2UBFIhS1YBk', {

--- a/example/proxy.js
+++ b/example/proxy.js
@@ -5,7 +5,7 @@ const agent = HttpsProxyAgent({
   ip: '111.111.111.111',
   port: 8080,
   // Remove this if you don't need to authenticate to your proxy.
-  auth: 'user:pass',
+  auth: 'user:pass'
 });
 
 const stream = ytdl('https://www.youtube.com/watch?v=2UBFIhS1YBk', {


### PR DESCRIPTION
[hallee's action](https://github.com/hallee/eslint-action) kept getting a 401 error

    Error Error: Received status code 401

you can see it on this run
https://github.com/fent/node-ytdl-core/runs/581237974

their repo doesn't have issues opened, and the repo it was forked from hasn't been updated in over a year. so I searched for other eslint actions and found https://github.com/marketplace/actions/eslint-annotate

but because there's still the issue that it does not run on PRs from forks, I restored @TimeForANinja's commit
https://github.com/a-b-r-o-w-n/eslint-action/issues/6
https://github.com/Neovici/github-actions-eslint-annotator/issues/10

this is something that will likely be fixed for github actions eventually. but for now we can't use fancy annotated actions :(
