### PR TITLE
add missing types for quality in download options

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,7 +5,7 @@ declare module 'ytdl-core' {
   namespace ytdl {
     type Filter = 'audioandvideo' | 'video' | 'videoonly' | 'audio' | 'audioonly' | ((format: videoFormat) => boolean);
     type downloadOptions = {
-      quality?: 'lowest' | 'highest' | 'highestaudio' | 'lowestaudio' | 'highestvideo' | 'lowestvideo' | string | number;
+      quality?: 'lowest' | 'highest' | 'highestaudio' | 'lowestaudio' | 'highestvideo' | 'lowestvideo' | string | number | string[] | number[];
       filter?: Filter;
       format?: videoFormat;
       range?: {


### PR DESCRIPTION
List of itags is also accepted: https://github.com/fent/node-ytdl-core/blob/04bcae0390ed575ed4ff61caa196aaa7e755580f/lib/util.js#L146-L153