### PR TITLE
Check if format contains URL

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -202,7 +202,7 @@ exports.filterFormats = (formats, filter) => {
         throw TypeError(`Given filter (${filter}) is not supported`);
       }
   }
-  return formats.filter(fn);
+  return formats.filter(format => !!format.url && fn(format));
 };
 
 


### PR DESCRIPTION
if the filtered format doesn't contain a URL field, miniget throws an uncatchable error.

to mitigate this, check if format contains a URL field.

if not and no formats are found, at least the Error can be caught.