### PR TITLE
Fixes slow speed when downloading videoonly/audioonly formats

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,7 @@
     }],
     "accessor-pairs": "warn",
     "array-callback-return": "error",
-    "complexity": ["warn", { "max": 21 }],
+    "complexity": ["warn", { "max": 25 }],
     "consistent-return": "warn",
     "curly": ["error", "multi-line", "consistent"],
     "dot-location": ["error", "property"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,7 @@
     }],
     "accessor-pairs": "warn",
     "array-callback-return": "error",
-    "complexity": "warn",
+    "complexity": ["warn", { "max": 21 }],
     "consistent-return": "warn",
     "curly": ["error", "multi-line", "consistent"],
     "dot-location": ["error", "property"],

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Attempts to download a video from the given url. Returns a [readable stream](htt
 * `liveBuffer` - How much time buffer to use for live videos in milliseconds. Default is `20000`.
 * `requestOptions` - Anything to merge into the request options which [miniget](https://github.com/fent/node-miniget) is called with, such as `headers`.
 * `highWaterMark` - How much of the video download to buffer into memory. See [node's docs](https://nodejs.org/api/stream.html#stream_constructor_new_stream_writable_options) for more. Defaults to 512KB.
-* `dlChunkSize` - The size of the download chunk in bytes, this is used when the chosen format is video only or audio only, the download in this case is separated into multiple chunks to avoid throttling. Defaults to 10MB.
+* `dlChunkSize` - The size of the download chunk in bytes. When the chosen format is video only or audio only, the download in this case is separated into multiple chunks to avoid throttling. Defaults to 10MB.
 * `lang` - The 2 character symbol of a language. Default is `en`.
 
 #### Event: info

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Attempts to download a video from the given url. Returns a [readable stream](htt
   ```
 * `format` - Primarily used to download specific video or audio streams. This can be a specific `format` object returned from `getInfo`.
   * Supplying this option will ignore the `filter` and `quality` options since the format is explicitly provided.
-* `dlChunkSize` - The size of the download chunk in bytes, this is used when the chosen format is video only or audio only, the download in this case is separated into multiple chunks to avoid throttling. Defaults to 10MB.
 * `range` - A byte range in the form `{start: INT, end: INT}` that specifies part of the file to download, ie {start: 10355705, end: 12452856}.
   * This downloads a portion of the file, and not a separately spliced video.
 * `begin` - What time in the video to begin. Supports formats `00:00:00.000`, `0ms, 0s, 0m, 0h`, or number of milliseconds. Example: `1:30`, `05:10.123`, `10m30s`.
@@ -58,6 +57,7 @@ Attempts to download a video from the given url. Returns a [readable stream](htt
 * `liveBuffer` - How much time buffer to use for live videos in milliseconds. Default is `20000`.
 * `requestOptions` - Anything to merge into the request options which [miniget](https://github.com/fent/node-miniget) is called with, such as `headers`.
 * `highWaterMark` - How much of the video download to buffer into memory. See [node's docs](https://nodejs.org/api/stream.html#stream_constructor_new_stream_writable_options) for more. Defaults to 512KB.
+* `dlChunkSize` - The size of the download chunk in bytes, this is used when the chosen format is video only or audio only, the download in this case is separated into multiple chunks to avoid throttling. Defaults to 10MB.
 * `lang` - The 2 character symbol of a language. Default is `en`.
 
 #### Event: info

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Attempts to download a video from the given url. Returns a [readable stream](htt
   ```
 * `format` - Primarily used to download specific video or audio streams. This can be a specific `format` object returned from `getInfo`.
   * Supplying this option will ignore the `filter` and `quality` options since the format is explicitly provided.
+* `dlChunkSize` - The size of the download chunk in bytes, this is used when the chosen format is video only or audio only, the download in this case is separated into multiple chunks to avoid throttling. Defaults to `10485760` which is `10 Megabytes`.
 * `range` - A byte range in the form `{start: INT, end: INT}` that specifies part of the file to download, ie {start: 10355705, end: 12452856}.
   * This downloads a portion of the file, and not a separately spliced video.
 * `begin` - What time in the video to begin. Supports formats `00:00:00.000`, `0ms, 0s, 0m, 0h`, or number of milliseconds. Example: `1:30`, `05:10.123`, `10m30s`.
@@ -140,8 +141,6 @@ ytdl cannot download videos that fall into the following
 * Regionally restricted (requires a [proxy](example/proxy.js))
 * Private (if you have access, requires [cookies](example/cookie.js))
 * Rentals (if you have access, requires [cookies](example/cookie.js))
-
-YouTube intentionally rate limits downloads, particularly audio only formats, likely to prevent bandwidth abuse. The download rate is still faster than a media player can play the video, even on 2x. See [#294](https://github.com/fent/node-ytdl-core/issues/294).
 
 Generated download links are valid for 6 hours, for the same IP address.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Attempts to download a video from the given url. Returns a [readable stream](htt
   ```
 * `format` - Primarily used to download specific video or audio streams. This can be a specific `format` object returned from `getInfo`.
   * Supplying this option will ignore the `filter` and `quality` options since the format is explicitly provided.
-* `dlChunkSize` - The size of the download chunk in bytes, this is used when the chosen format is video only or audio only, the download in this case is separated into multiple chunks to avoid throttling. Defaults to `10485760` which is `10 Megabytes`.
+* `dlChunkSize` - The size of the download chunk in bytes, this is used when the chosen format is video only or audio only, the download in this case is separated into multiple chunks to avoid throttling. Defaults to 10MB.
 * `range` - A byte range in the form `{start: INT, end: INT}` that specifies part of the file to download, ie {start: 10355705, end: 12452856}.
   * This downloads a portion of the file, and not a separately spliced video.
 * `begin` - What time in the video to begin. Supports formats `00:00:00.000`, `0ms, 0s, 0m, 0h`, or number of milliseconds. Example: `1:30`, `05:10.123`, `10m30s`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -178,7 +178,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
     stream._isDestroyed = true;
     if (req.abort) req.abort();
     req.end();
-    req.removeAllListeners('data');
+    req.removeListener('data', ondata);
     req.unpipe();
   };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,7 +82,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
     stream.emit('progress', chunk.length, downloaded, contentLength);
   };
 
-  // Download the file in chunks, in this case the default 10MB,
+  // Download the file in chunks, in this case the default is 10MB,
   // anything over this will cause youtube to throttle the download
   const dlChunkSize = options.dlChunkSize || 1024 * 1024 * 10;
   let req;
@@ -114,7 +114,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
     });
     pipeAndSetEvents();
   } else {
-    let requestOptions = Object.assign({}, options.requestOptions, {
+    const requestOptions = Object.assign({}, options.requestOptions, {
       maxReconnects: 6,
       maxRetries: 3,
       backoff: { inc: 500, max: 10000 },
@@ -127,9 +127,8 @@ const downloadFromInfoCallback = (stream, info, options) => {
       let end = start + dlChunkSize;
       const rangeEnd = options.range && options.range.end;
 
-      if (options.range) {
-        contentLength = (rangeEnd ? rangeEnd + 1 : format.contentLength) - start;
-      } else { contentLength = format.contentLength; }
+      contentLength = options.range ?
+        (rangeEnd ? rangeEnd + 1 : format.contentLength) - start : format.contentLength;
 
       const getNextChunk = () => {
         if (!rangeEnd && end >= contentLength) end = 0;

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,8 +87,8 @@ const downloadFromInfoCallback = (stream, info, options) => {
 
   let req;
   let shouldEnd = true;
-  stream.on('initialize-stream', () => {
-    if (shouldEnd) stream.removeAllListeners('initialize-stream');
+  stream.on('set-pipe-and-events', () => {
+    if (shouldEnd) stream.removeAllListeners('set-pipe-and-events');
     // Forward events from the request to the stream.
     [
       'abort', 'request', 'response', 'error', 'retry', 'reconnect',
@@ -113,7 +113,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
     req.on('progress', (segment, totalSegments) => {
       stream.emit('progress', segment.size, segment.num, totalSegments);
     });
-    stream.emit('initialize-stream');
+    stream.emit('set-pipe-and-events');
   } else {
     if (options.begin) {
       format.url += `&begin=${parseTime.humanStr(options.begin)}`;
@@ -129,12 +129,11 @@ const downloadFromInfoCallback = (stream, info, options) => {
       });
     }
 
-    const isDash = !format.audioBitrate || !format.qualityLabel;
+    const shouldBeChunked = !format.audioBitrate || !format.qualityLabel;
     let start = (options.range && options.range.start) || 0;
     let end = start + dlChunkSize;
-    let firstRun = true;
 
-    if (isDash) {
+    if (shouldBeChunked) {
       const heads = miniget(format.url);
       heads.once('response', res => {
         heads.abort();
@@ -143,6 +142,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
         contentLength = parseInt(res.headers['content-length'], 10);
 
         const getChunk = () => {
+          if (stream._isDestroyed) { return; }
           if (end >= contentLength) end = '';
           if (defaultEnd && end > defaultEnd) end = defaultEnd;
 
@@ -157,18 +157,14 @@ const downloadFromInfoCallback = (stream, info, options) => {
           });
           req.on('end', () => {
             if (end && end !== defaultEnd) {
-              if (firstRun) {
-                firstRun = false;
-                start += 1;
-              }
-              start += dlChunkSize;
+              start = end + 1;
               end += dlChunkSize;
               getChunk();
             }
           });
+          stream.emit('set-pipe-and-events');
         };
         getChunk();
-        stream.emit('initialize-stream');
       });
     } else {
       req = miniget(format.url, requestOptions);
@@ -179,7 +175,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
         }
       });
       req.on('data', ondata);
-      stream.emit('initialize-stream');
+      stream.emit('set-pipe-and-events');
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,9 @@ const createStream = options => {
   return stream;
 };
 
+// Download the file in chunks, in this case 10MB, anything
+// over this will cause youtube to throttle the download
+const dlChunkSize = 10485760;
 
 /**
  * Chooses a format to download.
@@ -83,6 +86,20 @@ const downloadFromInfoCallback = (stream, info, options) => {
   };
 
   let req;
+  let shouldEnd = true;
+  stream.on('initialize-stream', () => {
+    if (shouldEnd) stream.removeAllListeners('initialize-stream');
+    // Forward events from the request to the stream.
+    [
+      'abort', 'request', 'response', 'error', 'retry', 'reconnect',
+    ].forEach(event => {
+      req.prependListener(event, arg => {
+        stream.emit(event, arg);
+      });
+    });
+    req.pipe(stream, { end: shouldEnd });
+  });
+
   if (format.isHLS || format.isDashMPD) {
     req = m3u8stream(format.url, {
       chunkReadahead: +info.live_chunk_readahead,
@@ -96,6 +113,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
     req.on('progress', (segment, totalSegments) => {
       stream.emit('progress', segment.size, segment.num, totalSegments);
     });
+    stream.emit('initialize-stream');
   } else {
     if (options.begin) {
       format.url += `&begin=${parseTime.humanStr(options.begin)}`;
@@ -111,35 +129,67 @@ const downloadFromInfoCallback = (stream, info, options) => {
       });
     }
 
-    req = miniget(format.url, requestOptions);
+    const isDash = !format.audioBitrate || !format.qualityLabel;
+    let start = (options.range && options.range.start) || 0;
+    let end = start + dlChunkSize;
+    let firstRun = true;
 
-    req.on('response', res => {
-      if (stream._isDestroyed) { return; }
-      if (!contentLength) {
+    if (isDash) {
+      const heads = miniget(format.url);
+      heads.once('response', res => {
+        heads.abort();
+
+        const defaultEnd = options.range && options.range.end;
         contentLength = parseInt(res.headers['content-length'], 10);
-      }
-    });
-    req.on('data', ondata);
+
+        const getChunk = () => {
+          if (end >= contentLength) end = '';
+          if (defaultEnd && end > defaultEnd) end = defaultEnd;
+
+          requestOptions.headers = Object.assign({}, requestOptions.headers, {
+            Range: `bytes=${start}-${end}`,
+          });
+
+          shouldEnd = !end || end === defaultEnd;
+          req = miniget(format.url, requestOptions);
+          req.on('data', data => {
+            ondata(data);
+          });
+          req.on('end', () => {
+            if (end && end !== defaultEnd) {
+              if (firstRun) {
+                firstRun = false;
+                start += 1;
+              }
+              start += dlChunkSize;
+              end += dlChunkSize;
+              getChunk();
+            }
+          });
+        };
+        getChunk();
+        stream.emit('initialize-stream');
+      });
+    } else {
+      req = miniget(format.url, requestOptions);
+      req.on('response', res => {
+        if (stream._isDestroyed) { return; }
+        if (!contentLength) {
+          contentLength = parseInt(res.headers['content-length'], 10);
+        }
+      });
+      req.on('data', ondata);
+      stream.emit('initialize-stream');
+    }
   }
 
   stream.destroy = () => {
     stream._isDestroyed = true;
     if (req.abort) req.abort();
     req.end();
-    req.removeListener('data', ondata);
+    req.removeAllListeners('data');
     req.unpipe();
   };
-
-  // Forward events from the request to the stream.
-  [
-    'abort', 'request', 'response', 'error', 'retry', 'reconnect',
-  ].forEach(event => {
-    req.prependListener(event, arg => {
-      stream.emit(event, arg);
-    });
-  });
-
-  req.pipe(stream);
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,28 +135,35 @@ const downloadFromInfoCallback = (stream, info, options) => {
 
     if (shouldBeChunked) {
       const heads = miniget(format.url);
+
+      heads.on('error', e => stream.emit('error', e));
+
       heads.once('response', res => {
         heads.abort();
 
-        const defaultEnd = options.range && options.range.end;
-        contentLength = parseInt(res.headers['content-length'], 10);
+        const rangeEnd = options.range && options.range.end;
+
+        if (options.range) {
+          if (rangeEnd) contentLength = rangeEnd - start + 1;
+          else contentLength = parseInt(res.headers['content-length'], 10) - start;
+        } else { contentLength = parseInt(res.headers['content-length'], 10); }
 
         const getChunk = () => {
           if (stream._isDestroyed) { return; }
-          if (end >= contentLength) end = '';
-          if (defaultEnd && end > defaultEnd) end = defaultEnd;
+          if (!rangeEnd && end >= contentLength) end = 0;
+          if (rangeEnd && end > rangeEnd) end = rangeEnd;
 
           requestOptions.headers = Object.assign({}, requestOptions.headers, {
-            Range: `bytes=${start}-${end}`,
+            Range: `bytes=${start}-${end || ''}`,
           });
 
-          shouldEnd = !end || end === defaultEnd;
+          shouldEnd = !end || end === rangeEnd;
           req = miniget(format.url, requestOptions);
           req.on('data', data => {
             ondata(data);
           });
           req.on('end', () => {
-            if (end && end !== defaultEnd) {
+            if (end && end !== rangeEnd) {
               start = end + 1;
               end += dlChunkSize;
               getChunk();

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,9 +44,6 @@ const createStream = options => {
   return stream;
 };
 
-// Download the file in chunks, in this case 10MB, anything
-// over this will cause youtube to throttle the download
-const dlChunkSize = 10485760;
 
 /**
  * Chooses a format to download.
@@ -85,10 +82,12 @@ const downloadFromInfoCallback = (stream, info, options) => {
     stream.emit('progress', chunk.length, downloaded, contentLength);
   };
 
+  // Download the file in chunks, in this case the default 10MB,
+  // anything over this will cause youtube to throttle the download
+  const DL_CHUNK_SIZE = options.dlChunkSize || 10485760;
   let req;
   let shouldEnd = true;
-  stream.on('set-pipe-and-events', () => {
-    if (shouldEnd) stream.removeAllListeners('set-pipe-and-events');
+  const pipeAndSetEvents = () => {
     // Forward events from the request to the stream.
     [
       'abort', 'request', 'response', 'error', 'retry', 'reconnect',
@@ -98,7 +97,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
       });
     });
     req.pipe(stream, { end: shouldEnd });
-  });
+  };
 
   if (format.isHLS || format.isDashMPD) {
     req = m3u8stream(format.url, {
@@ -113,67 +112,60 @@ const downloadFromInfoCallback = (stream, info, options) => {
     req.on('progress', (segment, totalSegments) => {
       stream.emit('progress', segment.size, segment.num, totalSegments);
     });
-    stream.emit('set-pipe-and-events');
+    pipeAndSetEvents();
   } else {
-    if (options.begin) {
-      format.url += `&begin=${parseTime.humanStr(options.begin)}`;
-    }
     let requestOptions = Object.assign({}, options.requestOptions, {
       maxReconnects: 6,
       maxRetries: 3,
       backoff: { inc: 500, max: 10000 },
     });
-    if (options.range && (options.range.start || options.range.end)) {
-      requestOptions.headers = Object.assign({}, requestOptions.headers, {
-        Range: `bytes=${options.range.start || '0'}-${options.range.end || ''}`,
-      });
-    }
 
-    const shouldBeChunked = !format.audioBitrate || !format.qualityLabel;
-    let start = (options.range && options.range.start) || 0;
-    let end = start + dlChunkSize;
+    const shouldBeChunked = !format.hasAudio || !format.hasVideo;
 
     if (shouldBeChunked) {
-      const heads = miniget(format.url);
+      let start = (options.range && options.range.start) || 0;
+      let end = start + DL_CHUNK_SIZE;
+      const rangeEnd = options.range && options.range.end;
 
-      heads.on('error', e => stream.emit('error', e));
+      if (options.range) {
+        if (rangeEnd) contentLength = rangeEnd - start + 1;
+        else contentLength = format.contentLength - start;
+      } else { contentLength = format.contentLength; }
 
-      heads.once('response', res => {
-        heads.abort();
+      const getNextChunk = () => {
+        if (!rangeEnd && end >= contentLength) end = 0;
+        if (rangeEnd && end > rangeEnd) end = rangeEnd;
+        shouldEnd = !end || end === rangeEnd;
 
-        const rangeEnd = options.range && options.range.end;
+        requestOptions.headers = Object.assign({}, requestOptions.headers, {
+          Range: `bytes=${start}-${end || ''}`,
+        });
 
-        if (options.range) {
-          if (rangeEnd) contentLength = rangeEnd - start + 1;
-          else contentLength = parseInt(res.headers['content-length'], 10) - start;
-        } else { contentLength = parseInt(res.headers['content-length'], 10); }
-
-        const getChunk = () => {
+        req = miniget(format.url, requestOptions);
+        req.on('data', data => {
+          ondata(data);
+        });
+        req.on('end', () => {
           if (stream._isDestroyed) { return; }
-          if (!rangeEnd && end >= contentLength) end = 0;
-          if (rangeEnd && end > rangeEnd) end = rangeEnd;
-
-          requestOptions.headers = Object.assign({}, requestOptions.headers, {
-            Range: `bytes=${start}-${end || ''}`,
-          });
-
-          shouldEnd = !end || end === rangeEnd;
-          req = miniget(format.url, requestOptions);
-          req.on('data', data => {
-            ondata(data);
-          });
-          req.on('end', () => {
-            if (end && end !== rangeEnd) {
-              start = end + 1;
-              end += dlChunkSize;
-              getChunk();
-            }
-          });
-          stream.emit('set-pipe-and-events');
-        };
-        getChunk();
-      });
+          if (end && end !== rangeEnd) {
+            start = end + 1;
+            end += DL_CHUNK_SIZE;
+            getNextChunk();
+          }
+        });
+        pipeAndSetEvents();
+      };
+      getNextChunk();
     } else {
+      // Audio only and video only formats don't support begin
+      if (options.begin) {
+        format.url += `&begin=${parseTime.humanStr(options.begin)}`;
+      }
+      if (options.range && (options.range.start || options.range.end)) {
+        requestOptions.headers = Object.assign({}, requestOptions.headers, {
+          Range: `bytes=${options.range.start || '0'}-${options.range.end || ''}`,
+        });
+      }
       req = miniget(format.url, requestOptions);
       req.on('response', res => {
         if (stream._isDestroyed) { return; }
@@ -182,7 +174,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
         }
       });
       req.on('data', ondata);
-      stream.emit('set-pipe-and-events');
+      pipeAndSetEvents();
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@ const downloadFromInfoCallback = (stream, info, options) => {
 
   // Download the file in chunks, in this case the default 10MB,
   // anything over this will cause youtube to throttle the download
-  const DL_CHUNK_SIZE = options.dlChunkSize || 10485760;
+  const dlChunkSize = options.dlChunkSize || 1024 * 1024 * 10;
   let req;
   let shouldEnd = true;
   const pipeAndSetEvents = () => {
@@ -124,12 +124,11 @@ const downloadFromInfoCallback = (stream, info, options) => {
 
     if (shouldBeChunked) {
       let start = (options.range && options.range.start) || 0;
-      let end = start + DL_CHUNK_SIZE;
+      let end = start + dlChunkSize;
       const rangeEnd = options.range && options.range.end;
 
       if (options.range) {
-        if (rangeEnd) contentLength = rangeEnd - start + 1;
-        else contentLength = format.contentLength - start;
+        contentLength = (rangeEnd ? rangeEnd + 1 : format.contentLength) - start;
       } else { contentLength = format.contentLength; }
 
       const getNextChunk = () => {
@@ -142,14 +141,12 @@ const downloadFromInfoCallback = (stream, info, options) => {
         });
 
         req = miniget(format.url, requestOptions);
-        req.on('data', data => {
-          ondata(data);
-        });
+        req.on('data', ondata);
         req.on('end', () => {
           if (stream._isDestroyed) { return; }
           if (end && end !== rangeEnd) {
             start = end + 1;
-            end += DL_CHUNK_SIZE;
+            end += dlChunkSize;
             getNextChunk();
           }
         });

--- a/test/download-test.js
+++ b/test/download-test.js
@@ -83,7 +83,6 @@ describe('Download video', () => {
     });
 
     describe('right after request is made', () => {
-      after(() => { nock.cleanAll(); });
       it('Doesn\'t start the download', done => {
         const id = '_HSylqgVYQI';
         const scope = nock(id, {
@@ -175,7 +174,6 @@ describe('Download video', () => {
     });
 
     describe('right after request is made', () => {
-      after(() => { nock.cleanAll(); });
       it('Doesn\'t start the download', done => {
         const id = '_HSylqgVYQI';
         const scope = nock(id, {
@@ -397,7 +395,7 @@ describe('Download video', () => {
 
     it('Chunks video only and chunk size matches given size', done => {
       const dlChunkSize = 1024 * 200;
-      const stream = ytdl.downloadFromInfo(testInfo, { filter: format => !format.hasAudio, dlChunkSize });
+      const stream = ytdl.downloadFromInfo(testInfo, { filter: 'videoonly', dlChunkSize });
 
       stream.on('info', (info, format) => {
         nock.url(format.url)
@@ -405,7 +403,7 @@ describe('Download video', () => {
       });
 
       stream.on('request', req => {
-        const reqChunkSize = req.options.headers.range.split('-')[1];
+        const reqChunkSize = parseInt(req.options.headers.range.split('-')[1], 10);
         assert.equal(reqChunkSize, dlChunkSize);
         stream.removeAllListeners('request');
         done();
@@ -414,7 +412,7 @@ describe('Download video', () => {
 
     it('Chunks audio only and chunk size matches given size', done => {
       const dlChunkSize = 1024 * 200;
-      const stream = ytdl.downloadFromInfo(testInfo, { filter: format => !format.hasVideo, dlChunkSize });
+      const stream = ytdl.downloadFromInfo(testInfo, { filter: 'audioonly', dlChunkSize });
 
       stream.on('info', (info, format) => {
         nock.url(format.url)
@@ -422,7 +420,7 @@ describe('Download video', () => {
       });
 
       stream.on('request', req => {
-        const reqChunkSize = req.options.headers.range.split('-')[1];
+        const reqChunkSize = parseInt(req.options.headers.range.split('-')[1], 10);
         assert.equal(reqChunkSize, dlChunkSize);
         stream.removeAllListeners('request');
         done();

--- a/test/download-test.js
+++ b/test/download-test.js
@@ -353,7 +353,7 @@ describe('Download video', () => {
     });
 
     describe('that should be chunked', () => {
-      it('Starts downloading video successfully and data equal stored file', done => {
+      it('Starts downloading video successfully and data equal to stored file', done => {
         const scope = nock(id, {
           type: 'regular',
           player: true,

--- a/test/info-extras-test.js
+++ b/test/info-extras-test.js
@@ -91,6 +91,14 @@ describe('extras.getMedia()', () => {
       assert.equal(media.year, '1999');
     });
   });
+
+  describe('With invalid input', () => {
+    it('Should return an empty object', () => {
+      const media = extras.getMedia({ invalidObject: '' });
+      assert.ok(media);
+      assert.deepEqual(media, {});
+    });
+  });
 });
 
 


### PR DESCRIPTION
When trying to download anything other than ```audio + video``` formats the download speed becomes extremely slow, that's because YouTube throttles the connection when trying to download at a high rate, so the solution to this is to download the video in chunks, I found the optimal chunk size to be ```10MB```, when trying to go above that the throttling starts.
Fixes #660 
Fixes #490 
Fixes #294 
Fixes #327 
Fixes #473 