### PR TITLE
Working proxy example

### DIFF
--- a/example/proxy.js
+++ b/example/proxy.js
@@ -1,12 +1,9 @@
 const ytdl = require('..');
 const HttpsProxyAgent = require('https-proxy-agent');
 
-const agent = HttpsProxyAgent({
-  ip: '111.111.111.111',
-  port: 8080,
-  // Remove this if you don't need to authenticate to your proxy.
-  auth: 'user:pass',
-});
+// Remove 'user:pass@' if you don't need to authenticate to your proxy.
+const proxy = 'http://user:pass@111.111.111.111:8080';
+const agent = HttpsProxyAgent(proxy);
 
 const stream = ytdl('https://www.youtube.com/watch?v=2UBFIhS1YBk', {
   requestOptions: { agent },


### PR DESCRIPTION
So after testing the example with object (ip, port, auth) with around 10 proxies (5 with auth, 5 without auth) I've been always getting localhost errors such as `Error: connect ECONNREFUSED 127.0.0.1:8080` so Im updating the example to one that works