### PR TITLE
Change assert.equal (deprecated) to assert.strictEqual

### DIFF
--- a/test/download-test.js
+++ b/test/download-test.js
@@ -52,7 +52,7 @@ describe('Download video', () => {
     const stream = ytdl(id, { filter: filter });
     stream.on('error', err => {
       assert.ok(err);
-      assert.equal(err.message, 'Status code: 500');
+      assert.strictEqual(err.message, 'Status code: 500');
       scope.done();
       done();
     });
@@ -108,7 +108,7 @@ describe('Download video', () => {
         stream.on('abort', abort);
         stream.on('error', err => {
           assert.ok(abort.called);
-          assert.equal(err.message, 'socket hang up');
+          assert.strictEqual(err.message, 'socket hang up');
           scope.done();
           done();
         });
@@ -140,7 +140,7 @@ describe('Download video', () => {
         stream.on('abort', abort);
         stream.on('error', err => {
           assert.ok(abort.called);
-          assert.equal(err.message, 'socket hang up');
+          assert.strictEqual(err.message, 'socket hang up');
           scope.done();
           done();
         });
@@ -199,7 +199,7 @@ describe('Download video', () => {
         stream.on('abort', abort);
         stream.on('error', err => {
           assert.ok(abort.called);
-          assert.equal(err.message, 'socket hang up');
+          assert.strictEqual(err.message, 'socket hang up');
           scope.done();
           done();
         });
@@ -231,7 +231,7 @@ describe('Download video', () => {
         stream.on('abort', abort);
         stream.on('error', err => {
           assert.ok(abort.called);
-          assert.equal(err.message, 'socket hang up');
+          assert.strictEqual(err.message, 'socket hang up');
           scope.done();
           done();
         });
@@ -294,7 +294,7 @@ describe('Download video', () => {
       streamEqual(filestream, stream, (err, equal) => {
         assert.ifError(err);
         scope.done();
-        assert.equal(destroyedTimes, 1);
+        assert.strictEqual(destroyedTimes, 1);
         assert.ok(equal);
         done();
       });
@@ -343,7 +343,7 @@ describe('Download video', () => {
         streamEqual(filestream, stream, (err, equal) => {
           assert.ifError(err);
           scope.done();
-          assert.equal(destroyedTimes, 1);
+          assert.strictEqual(destroyedTimes, 1);
           assert.ok(equal);
           done();
         });
@@ -451,10 +451,10 @@ describe('Download video', () => {
           assert.ifError(err);
           scope.done();
           assert.ok(equal);
-          assert.equal(totalBytes, rangedSize);
-          assert.equal(downloadedBytes, totalBytes);
-          assert.equal(reqStart, start);
-          assert.equal(reqEnd, end);
+          assert.strictEqual(totalBytes, rangedSize);
+          assert.strictEqual(downloadedBytes, totalBytes);
+          assert.strictEqual(reqStart, start);
+          assert.strictEqual(reqEnd, end);
           done();
         });
       });
@@ -471,7 +471,7 @@ describe('Download video', () => {
 
       stream.on('request', req => {
         const reqChunkSize = parseInt(req.options.headers.range.split('-')[1], 10);
-        assert.equal(reqChunkSize, dlChunkSize);
+        assert.strictEqual(reqChunkSize, dlChunkSize);
         stream.removeAllListeners('request');
         done();
       });
@@ -488,7 +488,7 @@ describe('Download video', () => {
 
       stream.on('request', req => {
         const reqChunkSize = parseInt(req.options.headers.range.split('-')[1], 10);
-        assert.equal(reqChunkSize, dlChunkSize);
+        assert.strictEqual(reqChunkSize, dlChunkSize);
         stream.removeAllListeners('request');
         done();
       });
@@ -509,7 +509,7 @@ describe('Download video', () => {
       stream.on('error', done);
       stream.on('request', req => {
         const reqStart = parseInt(req.options.headers.range.replace('bytes=', '').split('-')[0], 10);
-        assert.equal(reqStart, start);
+        assert.strictEqual(reqStart, start);
         done();
       });
     });
@@ -530,7 +530,7 @@ describe('Download video', () => {
       stream.on('error', done);
       stream.on('request', req => {
         const reqStart = parseInt(req.options.headers.range.replace('bytes=', '').split('-')[0], 10);
-        assert.equal(reqStart, start);
+        assert.strictEqual(reqStart, start);
         done();
       });
     });
@@ -550,7 +550,7 @@ describe('Download video', () => {
       stream.on('error', done);
       stream.on('request', req => {
         const reqEnd = parseInt(req.options.headers.range.replace('bytes=', '').split('-')[1], 10);
-        assert.equal(reqEnd, end);
+        assert.strictEqual(reqEnd, end);
         done();
       });
     });
@@ -571,7 +571,7 @@ describe('Download video', () => {
       stream.on('error', done);
       stream.on('request', req => {
         const reqEnd = parseInt(req.options.headers.range.replace('bytes=', '').split('-')[1], 10);
-        assert.equal(reqEnd, end);
+        assert.strictEqual(reqEnd, end);
         done();
       });
     });
@@ -643,7 +643,7 @@ describe('Download video', () => {
       let progress = sinon.spy();
       stream.on('progress', progress);
       stream.on('end', () => {
-        assert.equal(body, 'onetwotres');
+        assert.strictEqual(body, 'onetwotres');
         assert.ok(progress.called);
         assert.deepEqual(progress.args, [
           [3, 1, 3],
@@ -699,7 +699,7 @@ describe('Download video', () => {
         stream.on('data', chunk => { body += chunk; });
         stream.on('end', () => {
           scope.done();
-          assert.equal(body, 'onetwotres');
+          assert.strictEqual(body, 'onetwotres');
           done();
         });
       });
@@ -715,7 +715,7 @@ describe('Download video', () => {
       let stream = ytdl(id);
       stream.on('error', err => {
         scope.done();
-        assert.equal(err.message, 'This video requires payment to watch.');
+        assert.strictEqual(err.message, 'This video requires payment to watch.');
         done();
       });
       stream.on('data', () => {
@@ -737,7 +737,7 @@ describe('Download video', () => {
       let stream = ytdl(id);
       stream.on('error', err => {
         scope.done();
-        assert.equal(err.message, 'This video is unavailable');
+        assert.strictEqual(err.message, 'This video is unavailable');
         done();
       });
       stream.on('data', () => {

--- a/test/info-extras-test.js
+++ b/test/info-extras-test.js
@@ -36,7 +36,7 @@ describe('extras.getAuthor()', () => {
     assertUserName(author.user);
     assert.ok(author.name);
     assertUserURL(author.user_url);
-    assert.equal(typeof author.verified, 'boolean');
+    assert.strictEqual(typeof author.verified, 'boolean');
     assert.number(author.subscriber_count);
   });
 
@@ -61,7 +61,7 @@ describe('extras.getAuthor()', () => {
       assertUserName(author.user);
       assert.ok(author.name);
       assertUserURL(author.user_url);
-      assert.equal(typeof author.verified, 'boolean');
+      assert.strictEqual(typeof author.verified, 'boolean');
       assert.number(author.subscriber_count);
     });
   });
@@ -73,9 +73,9 @@ describe('extras.getMedia()', () => {
     const info = require('./files/videos/vevo/expected-info.json');
     const media = extras.getMedia(info);
     assert.ok(media);
-    assert.equal(media.artist, 'Wu-Tang Clan');
+    assert.strictEqual(media.artist, 'Wu-Tang Clan');
     assertChannelURL(media.artist_url);
-    assert.equal(media.category, 'Music');
+    assert.strictEqual(media.category, 'Music');
     assertURL(media.category_url);
   });
 
@@ -84,11 +84,11 @@ describe('extras.getMedia()', () => {
       const info = require('./files/videos/game/expected-info.json');
       const media = extras.getMedia(info);
       assert.ok(media);
-      assert.equal(media.category, 'Gaming');
+      assert.strictEqual(media.category, 'Gaming');
       assertURL(media.category_url);
-      assert.equal(media.game, 'Pokémon Snap');
+      assert.strictEqual(media.game, 'Pokémon Snap');
       assertURL(media.game_url);
-      assert.equal(media.year, '1999');
+      assert.strictEqual(media.year, '1999');
     });
   });
 
@@ -154,7 +154,7 @@ describe('extras.getLikes()', () => {
     let html = fs.readFileSync(path.resolve(__dirname,
       'files/videos/regular/watch.json'), 'utf8');
     const likes = extras.getLikes(html);
-    assert.equal(typeof likes, 'number');
+    assert.strictEqual(typeof likes, 'number');
   });
 
   describe('With no likes', () => {
@@ -162,7 +162,7 @@ describe('extras.getLikes()', () => {
       let html = fs.readFileSync(path.resolve(__dirname,
         'files/videos/no-likes-or-dislikes/watch.json'), 'utf8');
       const likes = extras.getLikes(html);
-      assert.equal(likes, null);
+      assert.strictEqual(likes, null);
     });
   });
 });
@@ -172,7 +172,7 @@ describe('extras.getDislikes()', () => {
     let html = fs.readFileSync(path.resolve(__dirname,
       'files/videos/regular/watch.json'), 'utf8');
     const dislikes = extras.getDislikes(html);
-    assert.equal(typeof dislikes, 'number');
+    assert.strictEqual(typeof dislikes, 'number');
   });
 
   describe('With no dislikes', () => {
@@ -180,7 +180,7 @@ describe('extras.getDislikes()', () => {
       let html = fs.readFileSync(path.resolve(__dirname,
         'files/videos/no-likes-or-dislikes/watch.json'), 'utf8');
       const dislikes = extras.getDislikes(html);
-      assert.equal(dislikes, null);
+      assert.strictEqual(dislikes, null);
     });
   });
 });

--- a/test/info-test.js
+++ b/test/info-test.js
@@ -24,7 +24,7 @@ describe('ytdl.getInfo()', () => {
       let info = await ytdl.getInfo(id);
       scope.done();
       assert.ok(info.videoDetails.shortDescription.length);
-      assert.equal(info.formats.length, expectedInfo.formats.length);
+      assert.strictEqual(info.formats.length, expectedInfo.formats.length);
     });
 
     describe('Use ytdl.getBasicInfo()', () => {
@@ -35,7 +35,7 @@ describe('ytdl.getInfo()', () => {
 
         let info = await ytdl.getBasicInfo(id);
         scope.done();
-        assert.equal(info.formats.length, expectedInfo.formats.length);
+        assert.strictEqual(info.formats.length, expectedInfo.formats.length);
         assert.notEqual(info.formats[0].url, expectedInfo.formats[0].url);
       });
 
@@ -47,11 +47,11 @@ describe('ytdl.getInfo()', () => {
           });
 
           let info = await ytdl.getBasicInfo(id);
-          assert.equal(info.formats.length, expectedInfo.formats.length);
+          assert.strictEqual(info.formats.length, expectedInfo.formats.length);
           assert.notEqual(info.formats[0].url, expectedInfo.formats[0].url);
           let info2 = await ytdl.getInfo(id);
           scope.done();
-          assert.equal(info2.formats[0].url, expectedInfo.formats[0].url);
+          assert.strictEqual(info2.formats[0].url, expectedInfo.formats[0].url);
         });
       });
 
@@ -115,10 +115,10 @@ describe('ytdl.getInfo()', () => {
 
         let info1 = await ytdl.getInfo(testId);
         assert.ok(info1.videoDetails.shortDescription.length);
-        assert.equal(info1.formats.length, expectedInfo.formats.length);
+        assert.strictEqual(info1.formats.length, expectedInfo.formats.length);
         let info2 = await ytdl.getInfo(testId);
         scope.done();
-        assert.equal(info2, info1);
+        assert.strictEqual(info2, info1);
       });
     });
 
@@ -137,7 +137,7 @@ describe('ytdl.getInfo()', () => {
           assert.ifError(err);
           scope.done();
           assert.ok(info.videoDetails.shortDescription.length);
-          assert.equal(info.formats.length, expectedInfo.formats.length);
+          assert.strictEqual(info.formats.length, expectedInfo.formats.length);
           assert.ok(warn.called);
           done();
         });
@@ -168,7 +168,7 @@ describe('ytdl.getInfo()', () => {
       });
       let info = await ytdl.getInfo(id);
       scope.done();
-      assert.equal(info.formats.length, expectedInfo.formats.length);
+      assert.strictEqual(info.formats.length, expectedInfo.formats.length);
       assert.ok(info.videoDetails.age_restricted);
     });
 
@@ -191,7 +191,7 @@ describe('ytdl.getInfo()', () => {
       });
       let info = await ytdl.getInfo(id);
       scope.done();
-      assert.equal(info.formats.length, 10);
+      assert.strictEqual(info.formats.length, 10);
     });
   });
 
@@ -204,7 +204,7 @@ describe('ytdl.getInfo()', () => {
       });
       let info = await ytdl.getInfo(id);
       scope.done();
-      assert.equal(info.formats.length, 15);
+      assert.strictEqual(info.formats.length, 15);
     });
   });
 

--- a/test/sig-test.js
+++ b/test/sig-test.js
@@ -73,7 +73,7 @@ describe('Signature decipher', () => {
 
   const testDecipher = (tokens, input, expected) => {
     const result = sig.decipher(tokens, input);
-    assert.equal(result, expected);
+    assert.strictEqual(result, expected);
   };
 
   describe('properly apply actions based on tokens', () => {

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -169,55 +169,55 @@ describe('util.chooseFormat', () => {
   sortedFormats.sort(util.sortFormats);
 
   it('Is exposed in module', () => {
-    assert.equal(ytdl.chooseFormat, util.chooseFormat);
+    assert.strictEqual(ytdl.chooseFormat, util.chooseFormat);
   });
 
   describe('with no options', () => {
     it('Chooses highest quality', () => {
       const format = util.chooseFormat(sortedFormats, {});
-      assert.equal(format.itag, '43');
+      assert.strictEqual(format.itag, '43');
     });
   });
 
   describe('With lowest quality wanted', () => {
     it('Chooses lowest itag', () => {
       const format = util.chooseFormat(sortedFormats, { quality: 'lowest' });
-      assert.equal(format.itag, '138');
+      assert.strictEqual(format.itag, '138');
     });
   });
 
   describe('With highest audio quality wanted', () => {
     it('Chooses highest audio itag', () => {
       const format = util.chooseFormat(formats, { quality: 'highestaudio' });
-      assert.equal(format.itag, '43');
+      assert.strictEqual(format.itag, '43');
     });
   });
 
   describe('With lowest audio quality wanted', () => {
     it('Chooses lowest audio itag', () => {
       const format = util.chooseFormat(formats, { quality: 'lowestaudio' });
-      assert.equal(format.itag, '17');
+      assert.strictEqual(format.itag, '17');
     });
   });
 
   describe('With highest video quality wanted', () => {
     it('Chooses highest video itag', () => {
       const format = util.chooseFormat(formats, { quality: 'highestvideo' });
-      assert.equal(format.itag, '18');
+      assert.strictEqual(format.itag, '18');
     });
   });
 
   describe('With lowest video quality wanted', () => {
     it('Chooses lowest video itag', () => {
       const format = util.chooseFormat(formats, { quality: 'lowestvideo' });
-      assert.equal(format.itag, '17');
+      assert.strictEqual(format.itag, '17');
     });
   });
 
   describe('With itag given', () => {
     it('Chooses matching format', () => {
       const format = util.chooseFormat(sortedFormats, { quality: 5 });
-      assert.equal(format.itag, '5');
+      assert.strictEqual(format.itag, '5');
     });
 
     describe('that is not in the format list', () => {
@@ -232,14 +232,14 @@ describe('util.chooseFormat', () => {
   describe('With list of itags given', () => {
     it('Chooses matching format', () => {
       const format = util.chooseFormat(sortedFormats, { quality: [99, 160, 18] });
-      assert.equal(format.itag, '160');
+      assert.strictEqual(format.itag, '160');
     });
   });
 
   describe('With format object given', () => {
     it('Chooses given format without searching', () => {
       const format = util.chooseFormat(sortedFormats, { format: formats[0] });
-      assert.equal(format, formats[0]);
+      assert.strictEqual(format, formats[0]);
     });
   });
 
@@ -249,7 +249,7 @@ describe('util.chooseFormat', () => {
         const choosenFormat = util.chooseFormat(sortedFormats, {
           filter: format => format.container === 'mp4',
         });
-        assert.equal(choosenFormat.itag, '18');
+        assert.strictEqual(choosenFormat.itag, '18');
       });
     });
 
@@ -277,13 +277,13 @@ describe('util.filterFormats', () => {
   });
 
   it('Is exposed in module', () => {
-    assert.equal(ytdl.filterFormats, util.filterFormats);
+    assert.strictEqual(ytdl.filterFormats, util.filterFormats);
   });
 
   describe('that doesn\'t match any format', () => {
     it('Returns an empty list', () => {
       const list = util.filterFormats(formats, () => false);
-      assert.equal(list.length, 0);
+      assert.strictEqual(list.length, 0);
     });
   });
 
@@ -335,50 +335,50 @@ describe('util.filterFormats', () => {
 describe('util.between()', () => {
   it('`left` positioned at the start', () => {
     const rs = util.between('<b>hello there friend</b>', '<b>', '</b>');
-    assert.equal(rs, 'hello there friend');
+    assert.strictEqual(rs, 'hello there friend');
   });
 
   it('somewhere in the middle', () => {
     const rs = util.between('something everything nothing', ' ', ' ');
-    assert.equal(rs, 'everything');
+    assert.strictEqual(rs, 'everything');
   });
 
   it('not found', () => {
     const rs = util.between('oh oh _where_ is it', '<b>', '</b>');
-    assert.equal(rs, '');
+    assert.strictEqual(rs, '');
   });
 
   it('`right` before `left`', () => {
     const rs = util.between('>>> a <this> and that', '<', '>');
-    assert.equal(rs, 'this');
+    assert.strictEqual(rs, 'this');
   });
 
   it('`right` not found', () => {
     const rs = util.between('something [around[ somewhere', '[', ']');
-    assert.equal(rs, '');
+    assert.strictEqual(rs, '');
   });
 });
 
 
 describe('util.getURLVideoID()', () => {
   it('Is exposed in module', () => {
-    assert.equal(ytdl.getURLVideoID, util.getURLVideoID);
+    assert.strictEqual(ytdl.getURLVideoID, util.getURLVideoID);
   });
 
   it('Retrives the video ID from the url', () => {
     let id;
     id = util.getVideoID('http://www.youtube.com/watch?v=RAW_VIDEOID');
-    assert.equal(id, 'RAW_VIDEOID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = util.getVideoID('http://youtu.be/RAW_VIDEOID');
-    assert.equal(id, 'RAW_VIDEOID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = util.getVideoID('http://youtube.com/v/RAW_VIDEOID');
-    assert.equal(id, 'RAW_VIDEOID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = util.getVideoID('http://youtube.com/embed/RAW_VIDEOID');
-    assert.equal(id, 'RAW_VIDEOID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = util.getVideoID('https://music.youtube.com/watch?v=RAW_VIDEOID&list=RDAMVMmtLgabce8KQ');
-    assert.equal(id, 'RAW_VIDEOID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = util.getVideoID('https://gaming.youtube.com/watch?v=RAW_VIDEOID');
-    assert.equal(id, 'RAW_VIDEOID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     assert.throws(() => {
       util.getVideoID('https://any.youtube.com/watch?v=RAW_VIDEOID');
     }, /Not a YouTube domain/);
@@ -400,21 +400,21 @@ describe('util.getURLVideoID()', () => {
 
 describe('util.getVideoID()', () => {
   it('Is exposed in module', () => {
-    assert.equal(ytdl.getVideoID, util.getVideoID);
+    assert.strictEqual(ytdl.getVideoID, util.getVideoID);
   });
 
   it('Retrives the video ID from the url', () => {
     let id;
     id = util.getVideoID('http://www.youtube.com/watch?v=RAW_VIDEOID');
-    assert.equal(id, 'RAW_VIDEOID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = util.getVideoID('http://youtu.be/RAW_VIDEOID');
-    assert.equal(id, 'RAW_VIDEOID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = util.getVideoID('http://youtube.com/v/RAW_VIDEOID');
-    assert.equal(id, 'RAW_VIDEOID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = util.getVideoID('http://youtube.com/embed/RAW_VIDEOID');
-    assert.equal(id, 'RAW_VIDEOID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = util.getVideoID('_LENGTH_11_');
-    assert.equal(id, '_LENGTH_11_');
+    assert.strictEqual(id, '_LENGTH_11_');
     assert.throws(() => {
       util.getVideoID('http://youtube.com/RAW_VIDEOID');
     }, /No video id found: \S+/);
@@ -433,36 +433,36 @@ describe('util.getVideoID()', () => {
 
 describe('util.validateID()', () => {
   it('Is exposed in module', () => {
-    assert.equal(ytdl.validateID, util.validateID);
+    assert.strictEqual(ytdl.validateID, util.validateID);
   });
 
   it('Retrieves whether a string includes a video ID', () => {
     let rs;
     rs = util.validateID('RAW_VIDEOID');
-    assert.equal(rs, true);
+    assert.strictEqual(rs, true);
     rs = util.validateID('http://www.youtube.com/watch?v=RAW_VIDEOID');
-    assert.equal(rs, false);
+    assert.strictEqual(rs, false);
     rs = util.validateID('https://www.twitch.tv/user/v/1234');
-    assert.equal(rs, false);
+    assert.strictEqual(rs, false);
   });
 });
 
 
 describe('util.validateURL()', () => {
   it('Is exposed in module', () => {
-    assert.equal(ytdl.validateURL, util.validateURL);
+    assert.strictEqual(ytdl.validateURL, util.validateURL);
   });
 
   it('Retrieves whether a string includes a parsable video ID', () => {
     let rs;
     rs = util.validateURL('http://www.youtube.com/watch?v=RAW_VIDEOID');
-    assert.equal(rs, true);
+    assert.strictEqual(rs, true);
     rs = util.validateURL('RAW_VIDEOID');
-    assert.equal(rs, false);
+    assert.strictEqual(rs, false);
     rs = util.validateURL('https://www.twitch.tv/user/v/1234');
-    assert.equal(rs, false);
+    assert.strictEqual(rs, false);
     rs = util.validateURL('https://www.youtube.com/wartwzwerwer');
-    assert.equal(rs, false);
+    assert.strictEqual(rs, false);
   });
 });
 
@@ -514,37 +514,37 @@ describe('util.addFormatMeta()', () => {
   });
   describe('util.cutAfterJSON()', () => {
     it('Works with simple JSON', () => {
-      assert.equal(util.cutAfterJSON('{"a": 1, "b": 1}'), '{"a": 1, "b": 1}');
+      assert.strictEqual(util.cutAfterJSON('{"a": 1, "b": 1}'), '{"a": 1, "b": 1}');
     });
     it('Cut extra characters after JSON', () => {
-      assert.equal(util.cutAfterJSON('{"a": 1, "b": 1}abcd'), '{"a": 1, "b": 1}');
+      assert.strictEqual(util.cutAfterJSON('{"a": 1, "b": 1}abcd'), '{"a": 1, "b": 1}');
     });
     it('Tolerant to string constants', () => {
-      assert.equal(util.cutAfterJSON('{"a": "}1", "b": 1}abcd'), '{"a": "}1", "b": 1}');
+      assert.strictEqual(util.cutAfterJSON('{"a": "}1", "b": 1}abcd'), '{"a": "}1", "b": 1}');
     });
     it('Tolerant to string with escaped quoting', () => {
-      assert.equal(util.cutAfterJSON('{"a": "\\"}1", "b": 1}abcd'), '{"a": "\\"}1", "b": 1}');
+      assert.strictEqual(util.cutAfterJSON('{"a": "\\"}1", "b": 1}abcd'), '{"a": "\\"}1", "b": 1}');
     });
     it('works with nested', () => {
-      assert.equal(
+      assert.strictEqual(
         util.cutAfterJSON('{"a": "\\"1", "b": 1, "c": {"test": 1}}abcd'),
         '{"a": "\\"1", "b": 1, "c": {"test": 1}}',
       );
     });
     it('Works with utf', () => {
-      assert.equal(
+      assert.strictEqual(
         util.cutAfterJSON('{"a": "\\"фыва", "b": 1, "c": {"test": 1}}abcd'),
         '{"a": "\\"фыва", "b": 1, "c": {"test": 1}}',
       );
     });
     it('Works with \\\\ in string', () => {
-      assert.equal(
+      assert.strictEqual(
         util.cutAfterJSON('{"a": "\\\\фыва", "b": 1, "c": {"test": 1}}abcd'),
         '{"a": "\\\\фыва", "b": 1, "c": {"test": 1}}',
       );
     });
     it('Works with [ as start', () => {
-      assert.equal(
+      assert.strictEqual(
         util.cutAfterJSON('[{"a": 1}, {"b": 2}]abcd'),
         '[{"a": 1}, {"b": 2}]',
       );
@@ -565,15 +565,15 @@ describe('util.addFormatMeta()', () => {
 
 describe('util.parseAbbreviatedNumber', () => {
   it('Parses abbreviated numbers', () => {
-    assert.equal(util.parseAbbreviatedNumber('41K'), 41000);
-    assert.equal(util.parseAbbreviatedNumber('1.5M'), 1500000);
+    assert.strictEqual(util.parseAbbreviatedNumber('41K'), 41000);
+    assert.strictEqual(util.parseAbbreviatedNumber('1.5M'), 1500000);
   });
   it('Parses non-abbreviated numbers', () => {
-    assert.equal(util.parseAbbreviatedNumber('1234'), 1234);
-    assert.equal(util.parseAbbreviatedNumber('123.456'), 123.456);
+    assert.strictEqual(util.parseAbbreviatedNumber('1234'), 1234);
+    assert.strictEqual(util.parseAbbreviatedNumber('123.456'), 123.456);
   });
   it('Returns `null` when given non-number', () => {
-    assert.equal(util.parseAbbreviatedNumber('abc'), null);
+    assert.strictEqual(util.parseAbbreviatedNumber('abc'), null);
   });
 });
 


### PR DESCRIPTION
Make tests more strict 💪 .
`assert.equal` uses the `==` expression to evaluate (hence it's been deprecated), whereas `assert.strictEqual` uses `===` expression to evaluate.