### PR TITLE
use regex to extract player config from embed page

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -84,7 +84,7 @@ exports.getBasicInfo = async(id, options) => {
     // and requires an account logged in to view, try the embed page.
     let embedUrl = `${EMBED_URL + id}?${params}`;
     body = await miniget(embedUrl, options.requestOptions).text();
-    let jsonStr = util.between(body, '\'PLAYER_CONFIG\': ', '</script>');
+    let jsonStr = util.between(body, /['"]PLAYER_CONFIG['"]:\s?/, '</script>');
     let config;
     if (!jsonStr) {
       throw Error('Could not find player config');

--- a/lib/util.js
+++ b/lib/util.js
@@ -217,9 +217,17 @@ exports.filterFormats = (formats, filter) => {
  * @returns {string}
  */
 exports.between = (haystack, left, right) => {
-  let pos = haystack.indexOf(left);
-  if (pos === -1) { return ''; }
-  haystack = haystack.slice(pos + left.length);
+  let pos;
+  if (left instanceof RegExp) {
+    const match = haystack.match(left);
+    if (!match) { return ''; }
+    pos = match.index + match[0].length;
+  } else {
+    pos = haystack.indexOf(left);
+    if (pos === -1) { return ''; }
+    pos += left.length;
+  }
+  haystack = haystack.slice(pos);
   pos = haystack.indexOf(right);
   if (pos === -1) { return ''; }
   haystack = haystack.slice(0, pos);
@@ -399,6 +407,7 @@ exports.cutAfterJSON = mixedJson => {
   }
 
   if (!open) {
+    console.log(mixedJson);
     throw new Error(`Can't cut unsupported JSON (need to begin with [ or { ) but got: ${mixedJson[0]}`);
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -407,7 +407,6 @@ exports.cutAfterJSON = mixedJson => {
   }
 
   if (!open) {
-    console.log(mixedJson);
     throw new Error(`Can't cut unsupported JSON (need to begin with [ or { ) but got: ${mixedJson[0]}`);
   }
 


### PR DESCRIPTION
Fixes: https://github.com/fent/node-ytdl-core/issues/716

For some videos we get this response:
```
"PLAYER_CONFIG":{"attrs":{"height":"100%","width":"100%","id":"video-player"},
```
Instead of this
```
'PLAYER_CONFIG': {"attrs":{"id":"video-player","width":"100%","height":"100%"},
```
This happens randomly so there are no specific video examples for this.