### PR TITLE
Extra parenthesis

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ const ytdl = (link, options) => {
   const stream = createStream(options);
   ytdl.getInfo(link, options).then(info => {
     downloadFromInfoCallback(stream, info, options);
-  }, stream.emit.bind(stream, 'error'));
+  }, stream.emit.bind(stream, 'error');
   return stream;
 };
 module.exports = ytdl;


### PR DESCRIPTION
There is an extra parenthesis on "stream.emit.bind(stream, 'error');" In the original code there are two closing parenthesis. This is causing many crashes in my code.