### PR TITLE
Alert if ytdl-core is old

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,7 +41,7 @@
     "dot-location": ["error", "property"],
     "dot-notation": "error",
     "eqeqeq": "error",
-    "no-console": "error",
+    "no-console": ["error", { allow: ["warn"] }],
     "no-empty-function": "error",
     "no-floating-decimal": "error",
     "no-implied-eval": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,7 +41,7 @@
     "dot-location": ["error", "property"],
     "dot-notation": "error",
     "eqeqeq": "error",
-    "no-console": ["error", { allow: ["warn"] }],
+    "no-console": ["error", { "allow": ["warn"] }],
     "no-empty-function": "error",
     "no-floating-decimal": "error",
     "no-implied-eval": "error",

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const miniget = require('miniget');
 const m3u8stream = require('m3u8stream');
 const parseTime = require('m3u8stream/dist/parse-time');
 
+miniget("https://api.github.com/repos/fent/node-ytdl-core/releases/latest",{headers:{"User-Agent":"a/b"}}).text().then(a=>{"v4.0.5"!==JSON.parse(a).tag_name&&console.log("\x1B[31mWARNING:\x1B[0m ytdl-core is out of date! Update it using 'npm i ytdl-core'.")});
 
 /**
  * @param {string} link

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,11 @@ const parseTime = require('m3u8stream/dist/parse-time');
 
 const current = 'v4.0.5';
 const message = '\x1B[31mWARNING:\x1B[0m ytdl-core is out of date! Update it using "npm i ytdl-core".';
-miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
+miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } } )
   .text().then(response => {
-    if (JSON.parse(response).tag_name !== current) console.log(message);
+    if (JSON.parse(response).tag_name !== current) {
+      console.log(message);
+    }
 });
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,12 +10,12 @@ const parseTime = require('m3u8stream/dist/parse-time');
 
 const current = 'v4.0.5';
 const message = '\x1B[31mWARNING:\x1B[0m ytdl-core is out of date! Update it using "npm i ytdl-core".';
-miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } } )
+miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
   .text().then(response => {
     if (JSON.parse(response).tag_name !== current) {
-      console.log(message);
+      console.error(message);
     }
-});
+  });
 
 /**
  * @param {string} link

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ const miniget = require('miniget');
 const m3u8stream = require('m3u8stream');
 const parseTime = require('m3u8stream/dist/parse-time');
 
-const current = 'v4.0.5';
+const { version } = require('../package.json');
 const message = '\x1B[31mWARNING:\x1B[0m ytdl-core is out of date! Update it using "npm i ytdl-core".';
 miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
   .text().then(response => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,12 @@ const miniget = require('miniget');
 const m3u8stream = require('m3u8stream');
 const parseTime = require('m3u8stream/dist/parse-time');
 
-miniget("https://api.github.com/repos/fent/node-ytdl-core/releases/latest",{headers:{"User-Agent":"a/b"}}).text().then(a=>{"v4.0.5"!==JSON.parse(a).tag_name&&console.log("\x1B[31mWARNING:\x1B[0m ytdl-core is out of date! Update it using 'npm i ytdl-core'.")});
+const current = 'v4.0.5';
+const message = '\x1B[31mWARNING:\x1B[0m ytdl-core is out of date! Update it using "npm i ytdl-core".';
+miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
+  .text().then(response => {
+    if (JSON.parse(response).tag_name !== current) console.log(message);
+});
 
 /**
  * @param {string} link

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,14 +8,6 @@ const miniget = require('miniget');
 const m3u8stream = require('m3u8stream');
 const parseTime = require('m3u8stream/dist/parse-time');
 
-const { version } = require('../package.json');
-const message = '\x1B[31mWARNING:\x1B[0m ytdl-core is out of date! Update it using "npm i ytdl-core".';
-miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
-  .text().then(response => {
-    if (JSON.parse(response).tag_name !== current) {
-      console.error(message);
-    }
-  });
 
 /**
  * @param {string} link

--- a/lib/info.js
+++ b/lib/info.js
@@ -451,9 +451,9 @@ miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { he
       lastUpdateCheck = Date.now();
         if (JSON.parse(response).tag_name !== version) {
           console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update with "npm install ytdl-core@latest".');
-      }
-  }
-});
+        }
+    }
+  });
 
 // Export a few helpers.
 exports.validateID = urlUtils.validateID;

--- a/lib/info.js
+++ b/lib/info.js
@@ -426,6 +426,20 @@ const getM3U8 = async(url, options) => {
   return formats;
 };
 
+// Check for updates.
+const { version } = require('../package.json');
+lastUpdateCheck = Date.now();
+const checkForUpdates = () => {
+  if (!process.env.YTDL_NO_UPDATE && Date.now() - lastUpdateCheck >= 1000 * 60 * 60 * 12) {
+    miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
+      .text().then(response => {
+        if (JSON.parse(response).tag_name !== version) {
+          console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update with "npm install ytdl-core@latest".');
+        }
+      });
+  }
+}
+
 
 // Cache get info functions.
 // In case a user wants to get a video's info before downloading.
@@ -437,26 +451,17 @@ for (let funcName of ['getBasicInfo', 'getInfo']) {
    */
   const func = exports[funcName];
   exports[funcName] = (link, options = {}) => {
+    checkForUpdates();
     let id = urlUtils.getVideoID(link);
     const key = [funcName, id, options.lang].join('-');
     return exports.cache.getOrSet(key, () => func(id, options));
   };
 }
 
-const { version } = require('../package.json');
-let lastUpdateCheck = Date.now();
-miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
-  .text().then(response => {
-    if (!process.env.YTDL_NO_UPDATE && Date.now() - lastUpdateCheck >= 1000 * 60 * 60 * 12) {
-      lastUpdateCheck = Date.now();
-        if (JSON.parse(response).tag_name !== version) {
-          console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update with "npm install ytdl-core@latest".');
-        }
-    }
-  });
 
 // Export a few helpers.
 exports.validateID = urlUtils.validateID;
 exports.validateURL = urlUtils.validateURL;
 exports.getURLVideoID = urlUtils.getURLVideoID;
 exports.getVideoID = urlUtils.getVideoID;
+exports.checkForUpdates = checkForUpdates;

--- a/lib/info.js
+++ b/lib/info.js
@@ -428,7 +428,7 @@ const getM3U8 = async(url, options) => {
 
 // Check for updates.
 const { version } = require('../package.json');
-lastUpdateCheck = Date.now();
+let lastUpdateCheck = Date.now();
 const checkForUpdates = () => {
   if (!process.env.YTDL_NO_UPDATE && Date.now() - lastUpdateCheck >= 1000 * 60 * 60 * 12) {
     miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
@@ -438,7 +438,7 @@ const checkForUpdates = () => {
         }
       });
   }
-}
+};
 
 
 // Cache get info functions.

--- a/lib/info.js
+++ b/lib/info.js
@@ -330,7 +330,19 @@ const parseFormats = player_response => {
  * @param {Object} options
  * @returns {Promise<Object>}
  */
+const { version } = require('../package.json');
+let lastUpdateCheck = Date.now();
 exports.getInfo = async(id, options) => {
+  update = process.env.UPDATE;
+  miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
+    .text().then(response => {
+      if (update === 'always' || (update !== 'never' && Date.now() - lastUpdateCheck >= 43200000)) {
+        lastUpdateCheck = Date.now();
+        if (JSON.parse(response).tag_name !== version) {
+          console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update it using "npm install ytdl-core@latest".');
+        }
+      }
+    });
   let info = await exports.getBasicInfo(id, options);
   const hasManifest =
     info.player_response && info.player_response.streamingData && (

--- a/lib/info.js
+++ b/lib/info.js
@@ -330,19 +330,7 @@ const parseFormats = player_response => {
  * @param {Object} options
  * @returns {Promise<Object>}
  */
-const { version } = require('../package.json');
-let lastUpdateCheck = Date.now();
 exports.getInfo = async(id, options) => {
-  update = process.env.UPDATE;
-  miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
-    .text().then(response => {
-      if (update === 'always' || (update !== 'never' && Date.now() - lastUpdateCheck >= 43200000)) {
-        lastUpdateCheck = Date.now();
-        if (JSON.parse(response).tag_name !== version) {
-          console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update it using "npm install ytdl-core@latest".');
-        }
-      }
-    });
   let info = await exports.getBasicInfo(id, options);
   const hasManifest =
     info.player_response && info.player_response.streamingData && (
@@ -455,6 +443,17 @@ for (let funcName of ['getBasicInfo', 'getInfo']) {
   };
 }
 
+const { version } = require('../package.json');
+let lastUpdateCheck = Date.now();
+miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
+  .text().then(response => {
+    if (!process.env.YTDL_NO_UPDATE && Date.now() - lastUpdateCheck >= 1000 * 60 * 60 * 12) {
+      lastUpdateCheck = Date.now();
+       if (JSON.parse(response).tag_name !== version) {
+        console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update with "npm install ytdl-core@latest".');
+      }
+    }
+   });
 
 // Export a few helpers.
 exports.validateID = urlUtils.validateID;

--- a/lib/info.js
+++ b/lib/info.js
@@ -431,8 +431,9 @@ const { version } = require('../package.json');
 let lastUpdateCheck = Date.now();
 const checkForUpdates = () => {
   if (!process.env.YTDL_NO_UPDATE && Date.now() - lastUpdateCheck >= 1000 * 60 * 60 * 12) {
-    miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'ytdl-core' } })
-      .text().then(response => {
+    miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', {
+      headers: { 'User-Agent': 'ytdl-core' }
+      }).text().then(response => {
         if (JSON.parse(response).tag_name !== version) {
           console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update with "npm install ytdl-core@latest".');
         }

--- a/lib/info.js
+++ b/lib/info.js
@@ -449,11 +449,11 @@ miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { he
   .text().then(response => {
     if (!process.env.YTDL_NO_UPDATE && Date.now() - lastUpdateCheck >= 1000 * 60 * 60 * 12) {
       lastUpdateCheck = Date.now();
-       if (JSON.parse(response).tag_name !== version) {
-        console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update with "npm install ytdl-core@latest".');
+        if (JSON.parse(response).tag_name !== version) {
+          console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update with "npm install ytdl-core@latest".');
       }
     }
-   });
+  });
 
 // Export a few helpers.
 exports.validateID = urlUtils.validateID;

--- a/lib/info.js
+++ b/lib/info.js
@@ -431,7 +431,7 @@ const { version } = require('../package.json');
 let lastUpdateCheck = Date.now();
 const checkForUpdates = () => {
   if (!process.env.YTDL_NO_UPDATE && Date.now() - lastUpdateCheck >= 1000 * 60 * 60 * 12) {
-    miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'a/b' } })
+    miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { headers: { 'User-Agent': 'ytdl-core' } })
       .text().then(response => {
         if (JSON.parse(response).tag_name !== version) {
           console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update with "npm install ytdl-core@latest".');

--- a/lib/info.js
+++ b/lib/info.js
@@ -452,8 +452,8 @@ miniget('https://api.github.com/repos/fent/node-ytdl-core/releases/latest', { he
         if (JSON.parse(response).tag_name !== version) {
           console.warn('\x1b[33mWARNING:\x1B[0m ytdl-core is out of date! Update with "npm install ytdl-core@latest".');
       }
-    }
-  });
+  }
+});
 
 // Export a few helpers.
 exports.validateID = urlUtils.validateID;

--- a/test/nock.js
+++ b/test/nock.js
@@ -9,6 +9,7 @@ const MANIFEST_HOST = 'https://manifest.googlevideo.com';
 const M3U8_HOST = 'https://manifest.googlevideo.com';
 const EMBED_PATH = '/embed/';
 const INFO_PATH = '/get_video_info?';
+process.env.YTDL_NO_UPDATE = true;
 
 
 if (global.it) {


### PR DESCRIPTION
From my experience in the YTDL support server, upgrading the package to latest seems to be something many users forget to do, and they encounter errors because of it.

If merged, this PR would add an alert in the console if ytdl-core is outdated, along with instructions to update.

This requires no extra dependencies and has been made as minimal as possible so as not to add overhead.
To function, it relies on the GitHub API.

To maintain this feature, all that is required is to update the tag ('v4.0.5') in the if statement with each new release.
This was written in 5 minutes, so please make edits if desired.

By the way, thank you for keeping this library up-to-date; it's quite a gift.