### PR TITLE
Handle unicode encoded equals in ID token

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -104,7 +104,7 @@ const getIdentityToken = (id, options, key, throwIfNotFound) =>
     if (!match && throwIfNotFound) {
       throw new UnrecoverableError('Cookie header used in request, but unable to find YouTube identity token');
     }
-    return match && match[2];
+    return match && match[2].replace('\\u003d', '=');
   });
 
 


### PR DESCRIPTION
When running ytdl on a mobile device in [a chrome extension](https://github.com/benkaiser/Stretto-Helper-Extension) I'm working on, I was receiving ID_TOKEN with a unique encoded equals sign at the end.

The targeted fix here is to replace the individual bad character, but I'm open to other options. It may also be worth digging into why exactly this difference is triggered on mobile but not the desktop when running ytdl in the chrome extension.