### PR TITLE
Temp. fix age-restricted videos playback

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -42,7 +42,7 @@ const AGE_RESTRICTED_URLS = [
 exports.getBasicInfo = async(id, options) => {
   const retryOptions = Object.assign({}, miniget.defaultOptions, options.requestOptions);
   const isValid = info =>
-    info.player_response && (utils.playError(info.player_response, ['LOGIN_REQUIRED']) ||
+    info.player_response && (!utils.playError(info.player_response, ['UNPLAYABLE', 'LOGIN_REQUIRED']) ||
       info.player_response.streamingData || isRental(info.player_response));
   let info = await pipeline([id, options], retryOptions, isValid, [
     getJSONWatchPage,


### PR DESCRIPTION
This change fixes age-restricted playback, as /embed/ status returns UNPLAYABLE instead of LOGIN_REQUIRED

A better solution is to transform UNPLAYABLE to LOGIN_REQUIRED on getEmbedPage, so really unavaillable videos don't use all 3 endpoints