### PR TITLE
use weak timeout (rather than strong timeout)

### DIFF
--- a/example/ffmpeg.js
+++ b/example/ffmpeg.js
@@ -82,8 +82,6 @@ ffmpegProcess.on('close', () => {
   // Cleanup
   process.stdout.write('\n\n\n\n');
   clearInterval(progressbarHandle);
-  // Close the programm
-  process.exit(0);
 });
 
 // Link streams

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -9,7 +9,7 @@ module.exports = class Cache extends Map {
       clearTimeout(super.get(key).tid);
     }
     super.set(key, {
-      tid: setTimeout(this.delete.bind(this, key), this.timeout),
+      tid: setTimeout(this.delete.bind(this, key), this.timeout).unref(),
       value,
     });
   }


### PR DESCRIPTION
As per <https://nodejs.org/api/timers.html#timers_timeout_unref>, calling `.unref()` will mark the timer as weak in the event loop and then return the timeout object.

Fixes https://github.com/fent/node-ytdl-core/issues/819.