### PR TITLE
Fix Search Cache compatibility with Electron Apps

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,3 +1,5 @@
+const { setTimeout } = require('timers');
+
 // A cache that expires.
 module.exports = class Cache extends Map {
   constructor(timeout = 1000) {

--- a/lib/info.js
+++ b/lib/info.js
@@ -3,6 +3,7 @@ const querystring = require('querystring');
 const sax = require('sax');
 const miniget = require('miniget');
 const utils = require('./utils');
+const { setTimeout } = require('timers'); // Forces Node JS version of setTimeout for Electron based applications
 const formatUtils = require('./format-utils');
 const urlUtils = require('./url-utils');
 const extras = require('./info-extras');

--- a/lib/info.js
+++ b/lib/info.js
@@ -3,7 +3,8 @@ const querystring = require('querystring');
 const sax = require('sax');
 const miniget = require('miniget');
 const utils = require('./utils');
-const { setTimeout } = require('timers'); // Forces Node JS version of setTimeout for Electron based applications
+// Forces Node JS version of setTimeout for Electron based applications
+const { setTimeout } = require('timers');
 const formatUtils = require('./format-utils');
 const urlUtils = require('./url-utils');
 const extras = require('./info-extras');


### PR DESCRIPTION
The recent change made in v4.1.5 breaks compatibility with Electron based applications. This is because the renderer process within Electron uses a similar library as the one within Node JS, but has small differences to the actual library being used. You can read more about it (and the suggested fix) over at [electron/electron#21162](https://github.com/electron/electron/issues/21162).

This change uses the suggested line in the linked issue to specify that `setTimeout` should use the functionality built into Node instead of the Electron based one.

I've already tested this fix in my project and it seems to work fine with this change.