### PR TITLE
fix: remove html-entities from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2067,11 +2067,6 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
-    "html-entities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
-      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
-    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "lint:typings:fix": "tslint --fix typings/index.d.ts"
   },
   "dependencies": {
-    "html-entities": "^1.3.1",
     "m3u8stream": "^0.8.3",
     "miniget": "^4.0.0",
     "sax": "^1.1.3"


### PR DESCRIPTION
fixes fent/node-ytdl-core#826