### PR TITLE
feat: Access to the various getInfo miniget requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Gets metainfo from a video. Includes additional formats, and ready to download d
 `options` can have the following
 
 * `requestOptions` - Anything to merge into the request options which [miniget](https://github.com/fent/node-miniget) is called with, such as `headers`.
-* `reqCallback` - Provide a callback function that receives miniget request stream objects used while fetching metainfo.
+* `requestCallback` - Provide a callback function that receives miniget request stream objects used while fetching metainfo.
 * `lang` - The 2 character symbol of a language. Default is `en`.
 
 ### ytdl.downloadFromInfo(info, options)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Gets metainfo from a video. Includes additional formats, and ready to download d
 `options` can have the following
 
 * `requestOptions` - Anything to merge into the request options which [miniget](https://github.com/fent/node-miniget) is called with, such as `headers`.
+* `reqCallback` - Provide a callback function that receives the request stream object of all getInfo miniget requests.
 * `lang` - The 2 character symbol of a language. Default is `en`.
 
 ### ytdl.downloadFromInfo(info, options)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Gets metainfo from a video. Includes additional formats, and ready to download d
 `options` can have the following
 
 * `requestOptions` - Anything to merge into the request options which [miniget](https://github.com/fent/node-miniget) is called with, such as `headers`.
-* `reqCallback` - Provide a callback function that receives the request stream object of all getInfo miniget requests.
+* `reqCallback` - Provide a callback function that receives miniget request stream objects used while fetching metainfo.
 * `lang` - The 2 character symbol of a language. Default is `en`.
 
 ### ytdl.downloadFromInfo(info, options)

--- a/lib/info.js
+++ b/lib/info.js
@@ -121,7 +121,7 @@ const getWatchHTMLPageBody = (id, options) => {
   const url = getWatchHTMLURL(id, options);
   return exports.watchPageCache.getOrSet(url, () => {
     let req = miniget(url, options.requestOptions);
-    if (typeof options.requestCallback == 'function') options.requestCallback(req);
+    if (typeof options.requestCallback === 'function') options.requestCallback(req);
     return req.text();
   });
 };
@@ -131,7 +131,7 @@ const EMBED_URL = 'https://www.youtube.com/embed/';
 const getEmbedPageBody = (id, options) => {
   const embedUrl = `${EMBED_URL + id}?hl=${options.lang || 'en'}`;
   let req = miniget(embedUrl, options.requestOptions);
-  if (typeof options.requestCallback == 'function') options.requestCallback(req);
+  if (typeof options.requestCallback === 'function') options.requestCallback(req);
   return req.text();
 };
 
@@ -294,7 +294,7 @@ const getWatchJSONPage = async(id, options) => {
 
   const jsonUrl = getWatchJSONURL(id, options);
   let req = miniget(jsonUrl, reqOptions);
-  if (typeof options.requestCallback == 'function') options.requestCallback(req);
+  if (typeof options.requestCallback === 'function') options.requestCallback(req);
   let body = await req.text();
   let parsedBody = parseJSON('watch.json', 'body', body);
   if (parsedBody.reload === 'now') {
@@ -338,7 +338,7 @@ const getVideoInfoPage = async(id, options) => {
   url.searchParams.set('gl', 'US');
   url.searchParams.set('hl', options.lang || 'en');
   let req = miniget(url.toString(), options.requestOptions);
-  if (typeof options.requestCallback == 'function') options.requestCallback(req);
+  if (typeof options.requestCallback === 'function') options.requestCallback(req);
   let body = await req.text();
   let info = querystring.parse(body);
   info.player_response = findPlayerResponse('get_video_info', info);
@@ -437,7 +437,7 @@ const getDashManifest = (url, options) => new Promise((resolve, reject) => {
   };
   parser.onend = () => { resolve(formats); };
   const req = miniget(new URL(url, BASE_URL).toString(), options.requestOptions);
-  if (typeof options.requestCallback == 'function') options.requestCallback(req);
+  if (typeof options.requestCallback === 'function') options.requestCallback(req);
   req.setEncoding('utf8');
   req.on('error', reject);
   req.on('data', chunk => { parser.write(chunk); });
@@ -455,7 +455,7 @@ const getDashManifest = (url, options) => new Promise((resolve, reject) => {
 const getM3U8 = async(url, options) => {
   url = new URL(url, BASE_URL);
   let req = miniget(url.toString(), options.requestOptions);
-  if (typeof options.requestCallback == 'function') options.requestCallback(req);
+  if (typeof options.requestCallback === 'function') options.requestCallback(req);
   let body = await req.text();
   let formats = {};
   body

--- a/lib/info.js
+++ b/lib/info.js
@@ -49,7 +49,7 @@ exports.getBasicInfo = async(id, options) => {
       // eslint-disable-next-line max-len
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.101 Safari/537.36',
     }, options.requestOptions.headers);
-  if (!options.reqCallback || (typeof options.reqCallback !== 'function')) options.reqCallback = (req)=>{};
+  if (!options.reqCallback || (typeof options.reqCallback !== 'function')) options.reqCallback = () => {};
   const validate = info => {
     let playErr = utils.playError(info.player_response, ['ERROR'], UnrecoverableError);
     let privateErr = privateVideoError(info.player_response);

--- a/lib/info.js
+++ b/lib/info.js
@@ -49,7 +49,6 @@ exports.getBasicInfo = async(id, options) => {
       // eslint-disable-next-line max-len
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.101 Safari/537.36',
     }, options.requestOptions.headers);
-  if (!options.reqCallback || (typeof options.reqCallback !== 'function')) options.reqCallback = () => {};
   const validate = info => {
     let playErr = utils.playError(info.player_response, ['ERROR'], UnrecoverableError);
     let privateErr = privateVideoError(info.player_response);
@@ -122,7 +121,7 @@ const getWatchHTMLPageBody = (id, options) => {
   const url = getWatchHTMLURL(id, options);
   return exports.watchPageCache.getOrSet(url, () => {
     let req = miniget(url, options.requestOptions);
-    options.reqCallback(req);
+    if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
     return req.text();
   });
 };
@@ -132,7 +131,7 @@ const EMBED_URL = 'https://www.youtube.com/embed/';
 const getEmbedPageBody = (id, options) => {
   const embedUrl = `${EMBED_URL + id}?hl=${options.lang || 'en'}`;
   let req = miniget(embedUrl, options.requestOptions);
-  options.reqCallback(req);
+  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
   return req.text();
 };
 
@@ -295,7 +294,7 @@ const getWatchJSONPage = async(id, options) => {
 
   const jsonUrl = getWatchJSONURL(id, options);
   let req = miniget(jsonUrl, reqOptions);
-  options.reqCallback(req);
+  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
   let body = await req.text();
   let parsedBody = parseJSON('watch.json', 'body', body);
   if (parsedBody.reload === 'now') {
@@ -339,7 +338,7 @@ const getVideoInfoPage = async(id, options) => {
   url.searchParams.set('gl', 'US');
   url.searchParams.set('hl', options.lang || 'en');
   let req = miniget(url.toString(), options.requestOptions);
-  options.reqCallback(req);
+  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
   let body = await req.text();
   let info = querystring.parse(body);
   info.player_response = findPlayerResponse('get_video_info', info);
@@ -438,7 +437,7 @@ const getDashManifest = (url, options) => new Promise((resolve, reject) => {
   };
   parser.onend = () => { resolve(formats); };
   const req = miniget(new URL(url, BASE_URL).toString(), options.requestOptions);
-  options.reqCallback(req);
+  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
   req.setEncoding('utf8');
   req.on('error', reject);
   req.on('data', chunk => { parser.write(chunk); });

--- a/lib/info.js
+++ b/lib/info.js
@@ -121,7 +121,7 @@ const getWatchHTMLPageBody = (id, options) => {
   const url = getWatchHTMLURL(id, options);
   return exports.watchPageCache.getOrSet(url, () => {
     let req = miniget(url, options.requestOptions);
-    if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
+    if (typeof options.requestCallback == 'function') options.requestCallback(req);
     return req.text();
   });
 };
@@ -131,7 +131,7 @@ const EMBED_URL = 'https://www.youtube.com/embed/';
 const getEmbedPageBody = (id, options) => {
   const embedUrl = `${EMBED_URL + id}?hl=${options.lang || 'en'}`;
   let req = miniget(embedUrl, options.requestOptions);
-  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
+  if (typeof options.requestCallback == 'function') options.requestCallback(req);
   return req.text();
 };
 
@@ -294,7 +294,7 @@ const getWatchJSONPage = async(id, options) => {
 
   const jsonUrl = getWatchJSONURL(id, options);
   let req = miniget(jsonUrl, reqOptions);
-  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
+  if (typeof options.requestCallback == 'function') options.requestCallback(req);
   let body = await req.text();
   let parsedBody = parseJSON('watch.json', 'body', body);
   if (parsedBody.reload === 'now') {
@@ -338,7 +338,7 @@ const getVideoInfoPage = async(id, options) => {
   url.searchParams.set('gl', 'US');
   url.searchParams.set('hl', options.lang || 'en');
   let req = miniget(url.toString(), options.requestOptions);
-  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
+  if (typeof options.requestCallback == 'function') options.requestCallback(req);
   let body = await req.text();
   let info = querystring.parse(body);
   info.player_response = findPlayerResponse('get_video_info', info);
@@ -437,7 +437,7 @@ const getDashManifest = (url, options) => new Promise((resolve, reject) => {
   };
   parser.onend = () => { resolve(formats); };
   const req = miniget(new URL(url, BASE_URL).toString(), options.requestOptions);
-  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
+  if (typeof options.requestCallback == 'function') options.requestCallback(req);
   req.setEncoding('utf8');
   req.on('error', reject);
   req.on('data', chunk => { parser.write(chunk); });
@@ -455,7 +455,7 @@ const getDashManifest = (url, options) => new Promise((resolve, reject) => {
 const getM3U8 = async(url, options) => {
   url = new URL(url, BASE_URL);
   let req = miniget(url.toString(), options.requestOptions);
-  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
+  if (typeof options.requestCallback == 'function') options.requestCallback(req);
   let body = await req.text();
   let formats = {};
   body

--- a/lib/info.js
+++ b/lib/info.js
@@ -119,20 +119,14 @@ const isNotYetBroadcasted = player_response => {
 const getWatchHTMLURL = (id, options) => `${BASE_URL + id}&hl=${options.lang || 'en'}`;
 const getWatchHTMLPageBody = (id, options) => {
   const url = getWatchHTMLURL(id, options);
-  return exports.watchPageCache.getOrSet(url, () => {
-    let req = miniget(url, options.requestOptions);
-    if (typeof options.requestCallback === 'function') options.requestCallback(req);
-    return req.text();
-  });
+  return exports.watchPageCache.getOrSet(url, () => utils.exposedMiniget(url, options).text());
 };
 
 
 const EMBED_URL = 'https://www.youtube.com/embed/';
 const getEmbedPageBody = (id, options) => {
   const embedUrl = `${EMBED_URL + id}?hl=${options.lang || 'en'}`;
-  let req = miniget(embedUrl, options.requestOptions);
-  if (typeof options.requestCallback === 'function') options.requestCallback(req);
-  return req.text();
+  return utils.exposedMiniget(embedUrl, options).text();
 };
 
 
@@ -293,9 +287,7 @@ const getWatchJSONPage = async(id, options) => {
   }
 
   const jsonUrl = getWatchJSONURL(id, options);
-  let req = miniget(jsonUrl, reqOptions);
-  if (typeof options.requestCallback === 'function') options.requestCallback(req);
-  let body = await req.text();
+  const body = await utils.exposedMiniget(jsonUrl, options, reqOptions).text();
   let parsedBody = parseJSON('watch.json', 'body', body);
   if (parsedBody.reload === 'now') {
     await setIdentityToken('browser', false);
@@ -337,9 +329,7 @@ const getVideoInfoPage = async(id, options) => {
   url.searchParams.set('ps', 'default');
   url.searchParams.set('gl', 'US');
   url.searchParams.set('hl', options.lang || 'en');
-  let req = miniget(url.toString(), options.requestOptions);
-  if (typeof options.requestCallback === 'function') options.requestCallback(req);
-  let body = await req.text();
+  const body = await utils.exposedMiniget(url.toString(), options).text();
   let info = querystring.parse(body);
   info.player_response = findPlayerResponse('get_video_info', info);
   return info;
@@ -436,8 +426,7 @@ const getDashManifest = (url, options) => new Promise((resolve, reject) => {
     }
   };
   parser.onend = () => { resolve(formats); };
-  const req = miniget(new URL(url, BASE_URL).toString(), options.requestOptions);
-  if (typeof options.requestCallback === 'function') options.requestCallback(req);
+  const req = utils.exposedMiniget(new URL(url, BASE_URL).toString(), options);
   req.setEncoding('utf8');
   req.on('error', reject);
   req.on('data', chunk => { parser.write(chunk); });
@@ -454,9 +443,7 @@ const getDashManifest = (url, options) => new Promise((resolve, reject) => {
  */
 const getM3U8 = async(url, options) => {
   url = new URL(url, BASE_URL);
-  let req = miniget(url.toString(), options.requestOptions);
-  if (typeof options.requestCallback === 'function') options.requestCallback(req);
-  let body = await req.text();
+  const body = await utils.exposedMiniget(url.toString(), options).text();
   let formats = {};
   body
     .split('\n')

--- a/lib/info.js
+++ b/lib/info.js
@@ -119,14 +119,20 @@ const isNotYetBroadcasted = player_response => {
 const getWatchHTMLURL = (id, options) => `${BASE_URL + id}&hl=${options.lang || 'en'}`;
 const getWatchHTMLPageBody = (id, options) => {
   const url = getWatchHTMLURL(id, options);
-  return exports.watchPageCache.getOrSet(url, () => miniget(url, options.requestOptions).text());
+  return exports.watchPageCache.getOrSet(url, () => {
+    let req = miniget(url, options.requestOptions);
+    options.reqCallback(req);
+    return req.text();
+  });
 };
 
 
 const EMBED_URL = 'https://www.youtube.com/embed/';
 const getEmbedPageBody = (id, options) => {
   const embedUrl = `${EMBED_URL + id}?hl=${options.lang || 'en'}`;
-  return miniget(embedUrl, options.requestOptions).text();
+  let req = miniget(embedUrl, options.requestOptions);
+  options.reqCallback(req);
+  return req.text();
 };
 
 
@@ -287,7 +293,9 @@ const getWatchJSONPage = async(id, options) => {
   }
 
   const jsonUrl = getWatchJSONURL(id, options);
-  let body = await miniget(jsonUrl, reqOptions).text();
+  let req = miniget(jsonUrl, reqOptions);
+  options.reqCallback(req);
+  let body = await req.text();
   let parsedBody = parseJSON('watch.json', 'body', body);
   if (parsedBody.reload === 'now') {
     await setIdentityToken('browser', false);
@@ -329,7 +337,9 @@ const getVideoInfoPage = async(id, options) => {
   url.searchParams.set('ps', 'default');
   url.searchParams.set('gl', 'US');
   url.searchParams.set('hl', options.lang || 'en');
-  let body = await miniget(url.toString(), options.requestOptions).text();
+  let req = miniget(url.toString(), options.requestOptions);
+  options.reqCallback(req);
+  let body = await req.text();
   let info = querystring.parse(body);
   info.player_response = findPlayerResponse('get_video_info', info);
   return info;
@@ -427,6 +437,7 @@ const getDashManifest = (url, options) => new Promise((resolve, reject) => {
   };
   parser.onend = () => { resolve(formats); };
   const req = miniget(new URL(url, BASE_URL).toString(), options.requestOptions);
+  options.reqCallback(req);
   req.setEncoding('utf8');
   req.on('error', reject);
   req.on('data', chunk => { parser.write(chunk); });
@@ -443,7 +454,9 @@ const getDashManifest = (url, options) => new Promise((resolve, reject) => {
  */
 const getM3U8 = async(url, options) => {
   url = new URL(url, BASE_URL);
-  let body = await miniget(url.toString(), options.requestOptions).text();
+  let req = miniget(url.toString(), options.requestOptions);
+  options.reqCallback(req);
+  let body = await req.text();
   let formats = {};
   body
     .split('\n')

--- a/lib/info.js
+++ b/lib/info.js
@@ -49,6 +49,7 @@ exports.getBasicInfo = async(id, options) => {
       // eslint-disable-next-line max-len
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.101 Safari/537.36',
     }, options.requestOptions.headers);
+  if (!options.reqCallback || (typeof options.reqCallback !== 'function')) options.reqCallback = (req)=>{};
   const validate = info => {
     let playErr = utils.playError(info.player_response, ['ERROR'], UnrecoverableError);
     let privateErr = privateVideoError(info.player_response);

--- a/lib/info.js
+++ b/lib/info.js
@@ -455,7 +455,7 @@ const getDashManifest = (url, options) => new Promise((resolve, reject) => {
 const getM3U8 = async(url, options) => {
   url = new URL(url, BASE_URL);
   let req = miniget(url.toString(), options.requestOptions);
-  options.reqCallback(req);
+  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
   let body = await req.text();
   let formats = {};
   body

--- a/lib/sig.js
+++ b/lib/sig.js
@@ -1,7 +1,7 @@
 const { URL } = require('url');
-const miniget = require('miniget');
 const querystring = require('querystring');
 const Cache = require('./cache');
+const utils = require('./utils');
 
 
 // A shared cache to keep track of html5player.js tokens.
@@ -16,9 +16,7 @@ exports.cache = new Cache();
  * @returns {Promise<Array.<string>>}
  */
 exports.getTokens = (html5playerfile, options) => exports.cache.getOrSet(html5playerfile, async() => {
-  let req = miniget(html5playerfile, options.requestOptions);
-  if (typeof options.requestCallback === 'function') options.requestCallback(req);
-  let body = await req.text();
+  const body = await utils.exposedMiniget(html5playerfile, options).text();
   const tokens = exports.extractActions(body);
   if (!tokens || !tokens.length) {
     throw Error('Could not extract signature deciphering actions');

--- a/lib/sig.js
+++ b/lib/sig.js
@@ -16,7 +16,9 @@ exports.cache = new Cache();
  * @returns {Promise<Array.<string>>}
  */
 exports.getTokens = (html5playerfile, options) => exports.cache.getOrSet(html5playerfile, async() => {
-  let body = await miniget(html5playerfile, options.requestOptions).text();
+  let req = miniget(html5playerfile, options.requestOptions);
+  options.reqCallback(req);
+  let body = await req.text();
   const tokens = exports.extractActions(body);
   if (!tokens || !tokens.length) {
     throw Error('Could not extract signature deciphering actions');

--- a/lib/sig.js
+++ b/lib/sig.js
@@ -17,7 +17,7 @@ exports.cache = new Cache();
  */
 exports.getTokens = (html5playerfile, options) => exports.cache.getOrSet(html5playerfile, async() => {
   let req = miniget(html5playerfile, options.requestOptions);
-  options.reqCallback(req);
+  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
   let body = await req.text();
   const tokens = exports.extractActions(body);
   if (!tokens || !tokens.length) {

--- a/lib/sig.js
+++ b/lib/sig.js
@@ -17,7 +17,7 @@ exports.cache = new Cache();
  */
 exports.getTokens = (html5playerfile, options) => exports.cache.getOrSet(html5playerfile, async() => {
   let req = miniget(html5playerfile, options.requestOptions);
-  if (typeof options.requestCallback == 'function') options.requestCallback(req);
+  if (typeof options.requestCallback === 'function') options.requestCallback(req);
   let body = await req.text();
   const tokens = exports.extractActions(body);
   if (!tokens || !tokens.length) {

--- a/lib/sig.js
+++ b/lib/sig.js
@@ -17,7 +17,7 @@ exports.cache = new Cache();
  */
 exports.getTokens = (html5playerfile, options) => exports.cache.getOrSet(html5playerfile, async() => {
   let req = miniget(html5playerfile, options.requestOptions);
-  if (options.reqCallback && (typeof options.reqCallback === 'function')) options.reqCallback(req);
+  if (typeof options.requestCallback == 'function') options.requestCallback(req);
   let body = await req.text();
   const tokens = exports.extractActions(body);
   if (!tokens || !tokens.length) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -126,6 +126,19 @@ exports.playError = (player_response, statuses, ErrorType = Error) => {
   return null;
 };
 
+/**
+ * Does a miniget request and calls options.requestCallback if present
+ *
+ * @param {string} url the request url
+ * @param {Object} options an object with optional requestOptions and requestCallback parameters
+ * @param {Object} requestOptionsOverwrite overwrite of options.requestOptions
+ * @returns {miniget.Stream}
+ */
+exports.exposedMiniget = (url, options = {}, requestOptionsOverwrite) => {
+  const req = miniget(url, requestOptionsOverwrite || options.requestOptions);
+  if (typeof options.requestCallback === 'function') options.requestCallback(req);
+  return req;
+};
 
 /**
  * Temporary helper to help deprecating a few properties.

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -180,3 +180,54 @@ describe('utils.checkForUpdates', () => {
     });
   });
 });
+
+describe('utils.exposedMiniget', () => {
+  it('does not error with undefined requestOptionsOverwrite', async() => {
+    const scope = nock('https://test.com').get('/').reply(200, 'nice');
+    const req = utils.exposedMiniget('https://test.com/', {});
+    await req.text();
+    scope.done();
+  });
+
+  it('does not error without options', async() => {
+    const scope = nock('https://test.com').get('/').reply(200, 'nice');
+    const req = utils.exposedMiniget('https://test.com/');
+    await req.text();
+    scope.done();
+  });
+
+  it('does not error without options', async() => {
+    const scope = nock('https://test.com').get('/').reply(200, 'nice');
+    const req = utils.exposedMiniget('https://test.com/');
+    assert.equal(await req.text(), 'nice');
+    scope.done();
+  });
+
+  it('calls a provided callback with the req object', async() => {
+    const scope = nock('https://test.com').get('/').reply(200, 'nice');
+    let cbReq;
+    const requestCallback = r => cbReq = r;
+    const req = utils.exposedMiniget('https://test.com/', { requestCallback });
+    await req.text();
+    assert.equal(cbReq, req);
+    scope.done();
+  });
+
+  it('it uses requestOptions', async() => {
+    const scope = nock('https://test.com', { reqheaders: { auth: 'a' } }).get('/').reply(200, 'nice');
+    const req = utils.exposedMiniget('https://test.com/', { requestOptions: { headers: { auth: 'a' } } });
+    await req.text();
+    scope.done();
+  });
+
+  it('it prefers requestOptionsOverwrite over requestOptions', async() => {
+    const scope = nock('https://test.com', { reqheaders: { auth: 'b' } }).get('/').reply(200, 'nice');
+    const req = utils.exposedMiniget(
+      'https://test.com/',
+      { requestOptions: { headers: { auth: 'a' } } },
+      { headers: { auth: 'b' } },
+    );
+    await req.text();
+    scope.done();
+  });
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,6 +7,7 @@ declare module 'ytdl-core' {
 
     interface getInfoOptions {
       lang?: string;
+      requestCallback?: () => {};
       requestOptions?: {};
     }
 


### PR DESCRIPTION
In my use case it is to monitor compressed/uncompressed bandwidth, but there could be many other uses (i.e. applying a timeout or request logging)

See discussion: https://github.com/fent/node-ytdl-core/discussions/899

I'm suggesting a callback which would receive each request in the getInfo pipeline, including retries.

Perhaps there is a better way... but this is my solution which is working well on my test app.