### PR TITLE
fix: Handle HLS audio only request edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ ytdl('http://www.youtube.com/watch?v=aqz-KE-bpKQ')
 # API
 ### ytdl(url, [options])
 
-Attempts to download a video from the given url. Returns a [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable). `options` can have the following, in addition to any [`getInfo()` option](#async-ytdl.getinfo(url%2C-%5Boptions%5D)) and [`chooseFormat()` option](#ytdl.downloadfrominfo(info%2C-options)).
+Attempts to download a video from the given url. Returns a [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable). `options` can have the following, in addition to any [`getInfo()` option](#async-ytdlgetinfourl-options) and [`chooseFormat()` option](#ytdlchooseformatformats-options).
 
 * `range` - A byte range in the form `{start: INT, end: INT}` that specifies part of the file to download, ie {start: 10355705, end: 12452856}. Not supported on segmented (DASH MPD, m3u8) formats.
   * This downloads a portion of the file, and not a separately spliced video.
 * `begin` - What time in the video to begin. Supports formats `00:00:00.000`, `0ms, 0s, 0m, 0h`, or number of milliseconds. Example: `1:30`, `05:10.123`, `10m30s`.
   * For live videos, this also accepts a unix timestamp or Date object, and defaults to `Date.now()`.
-  * This option is not very reliable for non-live videos, see [#129](https://github.com/fent/node-ytdl-core/issues/129), [#219](https://github.com/fent/node-ytdl-core/issues/219).
+  * This option is not very reliable for non-live videos, see [#129](https://github.com/fent/node-ytdl-core/issues/129) and [#219](https://github.com/fent/node-ytdl-core/issues/219).
 * `liveBuffer` - How much time buffer to use for live videos in milliseconds. Default is `20000`.
 * `highWaterMark` - How much of the video download to buffer into memory. See [node's docs](https://nodejs.org/api/stream.html#stream_constructor_new_stream_writable_options) for more. Defaults to 512KB.
 * `dlChunkSize` - When the chosen format is video only or audio only, the download is separated into multiple chunks to avoid throttling. This option specifies the size of each chunk in bytes. Setting it to 0 disables chunking. Defaults to 10MB.
@@ -81,7 +81,7 @@ Can be used if you'd like to choose a format yourself. Throws an Error if it fai
 
 `options` can have the following
 
-* `quality` - Video quality to download. Can be an [itag value](http://en.wikipedia.org/wiki/YouTube#Quality_and_formats), a list of itag values, or `highest`/`lowest`/`highestaudio`/`lowestaudio`/`highestvideo`/`lowestvideo`. `highestaudio`/`lowestaudio`/`highestvideo`/`lowestvideo` all prefer audio/video only respectively. Defaults to `highest`, which prefers formats with both video and audio.
+* `quality` - Video quality to download. Can be an [itag value](http://en.wikipedia.org/wiki/YouTube#Quality_and_formats), a list of itag values, or one of these strings: `highest`/`lowest`/`highestaudio`/`lowestaudio`/`highestvideo`/`lowestvideo`. `highestaudio`/`lowestaudio` try to minimize video bitrate for equally good audio formats while `highestvideo`/`lowestvideo` try to minimize audio respectively. Defaults to `highest`, which prefers formats with both video and audio.
 
   A typical video's formats will be sorted in the following way using `quality: 'highest'`
   ```
@@ -147,6 +147,7 @@ ytdl cannot download videos that fall into the following
 * Private (if you have access, requires [cookies](example/cookies.js))
 * Rentals (if you have access, requires [cookies](example/cookies.js))
 * YouTube Premium content (if you have access, requires [cookies](example/cookies.js))
+* Only [HLS Livestreams](https://en.wikipedia.org/wiki/HTTP_Live_Streaming) are currently supported. Other formats will get filtered out in ytdl.chooseFormats
 
 Generated download links are valid for 6 hours, and may only be downloadable from the same IP address.
 

--- a/lib/format-utils.js
+++ b/lib/format-utils.js
@@ -121,16 +121,18 @@ exports.chooseFormat = (formats, options) => {
       format = formats[formats.length - 1];
       break;
 
-    case 'highestaudio':
+    case 'highestaudio': {
       formats = exports.filterFormats(formats, 'audio');
       formats.sort(sortFormatsByAudio);
-      // The formats video quality decreases with rank
-      // So we just need to skip forward to the last format the with same audio quality
-      // To get the format with highest audio + lowest video
-      do {
-        format = formats.shift();
-      } while (format && sortFormatsByAudio(format, formats[0]) === 0);
+      // Filter for only the best audio format
+      const bestAudioFormat = formats[0];
+      formats = formats.filter(f => sortFormatsByAudio(bestAudioFormat, f) === 0);
+      // Check for the worst video quality for the best audio quality and pick according
+      // This does not loose default sorting of video encoding and bitrate
+      const worstVideoQuality = formats.map(f => parseInt(f.qualityLabel) || 0).sort((a, b) => a - b)[0];
+      format = formats.find(f => (parseInt(f.qualityLabel) || 0) === worstVideoQuality);
       break;
+    }
 
     case 'lowestaudio':
       formats = exports.filterFormats(formats, 'audio');
@@ -138,16 +140,18 @@ exports.chooseFormat = (formats, options) => {
       format = formats[formats.length - 1];
       break;
 
-    case 'highestvideo':
+    case 'highestvideo': {
       formats = exports.filterFormats(formats, 'video');
       formats.sort(sortFormatsByVideo);
-      // The formats audio quality decreases with rank
-      // So we just need to skip forward to the last format with the same video quality
-      // To get the format with highest video + lowest audio
-      do {
-        format = formats.shift();
-      } while (format && sortFormatsByVideo(format, formats[0]) === 0);
+      // Filter for only the best video format
+      const bestVideoFormat = formats[0];
+      formats = formats.filter(f => sortFormatsByVideo(bestVideoFormat, f) === 0);
+      // Check for the worst audio quality for the best video quality and pick according
+      // This does not loose default sorting of audio encoding and bitrate
+      const worstAudioQuality = formats.map(f => f.audioBitrate || 0).sort((a, b) => a - b)[0];
+      format = formats.find(f => (f.audioBitrate || 0) === worstAudioQuality);
       break;
+    }
 
     case 'lowestvideo':
       formats = exports.filterFormats(formats, 'video');

--- a/lib/format-utils.js
+++ b/lib/format-utils.js
@@ -124,6 +124,9 @@ exports.chooseFormat = (formats, options) => {
     case 'highestaudio':
       formats = exports.filterFormats(formats, 'audio');
       formats.sort(sortFormatsByAudio);
+      // The formats video quality decreases with rank
+      // So we just need to skip forward to the last format the with same audio quality
+      // To get the format with highest audio + lowest video
       do {
         format = formats.shift();
       } while (format && sortFormatsByAudio(format, formats[0]) === 0);
@@ -138,6 +141,9 @@ exports.chooseFormat = (formats, options) => {
     case 'highestvideo':
       formats = exports.filterFormats(formats, 'video');
       formats.sort(sortFormatsByVideo);
+      // The formats audio quality decreases with rank
+      // So we just need to skip forward to the last format with the same video quality
+      // To get the format with highest video + lowest audio
       do {
         format = formats.shift();
       } while (format && sortFormatsByVideo(format, formats[0]) === 0);

--- a/lib/format-utils.js
+++ b/lib/format-utils.js
@@ -62,12 +62,6 @@ const sortFormatsByAudio = (a, b) => sortFormatsBy(a, b, [
 ]);
 
 
-const sortFormatsByHighAudioAndLowVideo = (a, b) => sortFormatsBy(a, b, [
-  getAudioBitrate,
-  format => -format.bitrate,
-]);
-
-
 /**
  * Sort formats from highest quality to lowest.
  *
@@ -106,39 +100,17 @@ exports.chooseFormat = (formats, options) => {
     return options.format;
   }
 
-  let format;
-  if (formats.some(fmt => fmt.isHLS)) {
-    // It's a live stream
-    const isAudioQualityRequest = options.quality &&
-      typeof options.quality === 'string' &&
-      /(lowest|highest)audio/.test(options.quality);
-    const isAudioFilterRequest = options.filter &&
-      typeof options.filter === 'string' &&
-      /audio(only)?/.test(options.filter);
-
-    if (isAudioQualityRequest || isAudioFilterRequest) {
-      formats = formats.filter(fmt => fmt.isHLS);
-
-      if (isAudioQualityRequest && options.quality === 'lowestaudio') {
-        format = formats[formats.length - 1];
-      } else {
-        // A `highestaudio` quality and/or an audio filter
-        // has been requested
-        //
-        // Provide highest audio bitrate with lowest video bitrate
-        // in order for the user to preserve bandwidth
-        formats.sort(sortFormatsByHighAudioAndLowVideo);
-        format = formats[0];
-      }
-
-      return format;
-    }
-  }
-
   if (options.filter) {
     formats = exports.filterFormats(formats, options.filter);
   }
 
+  // We currently only support HLS-Formats for livestreams
+  // So we (now) remove all non-HLS streams
+  if (formats.some(fmt => fmt.isHLS)) {
+    formats = formats.filter(fmt => fmt.isHLS || !fmt.isLive);
+  }
+
+  let format;
   const quality = options.quality || 'highest';
   switch (quality) {
     case 'highest':
@@ -152,7 +124,9 @@ exports.chooseFormat = (formats, options) => {
     case 'highestaudio':
       formats = exports.filterFormats(formats, 'audio');
       formats.sort(sortFormatsByAudio);
-      format = formats[0];
+      do {
+        format = formats.shift();
+      } while (format && sortFormatsByAudio(format, formats[0]) === 0);
       break;
 
     case 'lowestaudio':
@@ -164,7 +138,9 @@ exports.chooseFormat = (formats, options) => {
     case 'highestvideo':
       formats = exports.filterFormats(formats, 'video');
       formats.sort(sortFormatsByVideo);
-      format = formats[0];
+      do {
+        format = formats.shift();
+      } while (format && sortFormatsByVideo(format, formats[0]) === 0);
       break;
 
     case 'lowestvideo':

--- a/lib/format-utils.js
+++ b/lib/format-utils.js
@@ -62,6 +62,13 @@ const sortFormatsByAudio = (a, b) => sortFormatsBy(a, b, [
 ]);
 
 
+const sortFormatsByHighAudioAndLowVideo = (a, b) => sortFormatsBy(a, b, [
+  getAudioBitrate,
+  format => -parseInt(format.qualityLabel) || 0,
+  format => -format.bitrate || 0,
+]);
+
+
 /**
  * Sort formats from highest quality to lowest.
  *
@@ -100,11 +107,40 @@ exports.chooseFormat = (formats, options) => {
     return options.format;
   }
 
+  let format;
+  if (formats.some(fmt => fmt.isHLS)) {
+    const testAudioQuality = options.quality &&
+      typeof options.quality === 'string' &&
+      /(lowest|highest)audio/.test(options.quality);
+    const testAudioFilter = options.filter &&
+      typeof options.filter === 'string' &&
+      /audio(only)?/.test(options.filter);
+
+    if (testAudioQuality || testAudioFilter) {
+      formats = formats.filter(fmt => fmt.isHLS);
+      if (testAudioQuality) {
+        switch (options.quality) {
+          case 'highestaudio':
+            formats.sort(sortFormatsByHighAudioAndLowVideo);
+            format = formats[0];
+            break;
+
+          case 'lowestaudio':
+            format = formats[formats.length - 1];
+            break;
+        }
+      } else {
+        formats.sort(sortFormatsByHighAudioAndLowVideo);
+        format = formats[0];
+      }
+      return format;
+    }
+  }
+
   if (options.filter) {
     formats = exports.filterFormats(formats, options.filter);
   }
 
-  let format;
   const quality = options.quality || 'highest';
   switch (quality) {
     case 'highest':

--- a/lib/format-utils.js
+++ b/lib/format-utils.js
@@ -108,6 +108,7 @@ exports.chooseFormat = (formats, options) => {
 
   let format;
   if (formats.some(fmt => fmt.isHLS)) {
+    // It's a live stream
     const isAudioQualityRequest = options.quality &&
       typeof options.quality === 'string' &&
       /(lowest|highest)audio/.test(options.quality);
@@ -121,6 +122,11 @@ exports.chooseFormat = (formats, options) => {
       if (isAudioQualityRequest && options.quality === 'lowestaudio') {
         format = formats[formats.length - 1];
       } else {
+        // A `highestaudio` quality and/or an audio filter
+        // has been requested
+        //
+        // Provide highest audio bitrate with lowest video bitrate
+        // in order for the user to preserve bandwidth
         formats.sort(sortFormatsByHighAudioAndLowVideo);
         format = formats[0];
       }

--- a/lib/format-utils.js
+++ b/lib/format-utils.js
@@ -64,8 +64,7 @@ const sortFormatsByAudio = (a, b) => sortFormatsBy(a, b, [
 
 const sortFormatsByHighAudioAndLowVideo = (a, b) => sortFormatsBy(a, b, [
   getAudioBitrate,
-  format => -parseInt(format.qualityLabel) || 0,
-  format => -format.bitrate || 0,
+  format => -format.bitrate,
 ]);
 
 

--- a/lib/format-utils.js
+++ b/lib/format-utils.js
@@ -108,30 +108,23 @@ exports.chooseFormat = (formats, options) => {
 
   let format;
   if (formats.some(fmt => fmt.isHLS)) {
-    const testAudioQuality = options.quality &&
+    const isAudioQualityRequest = options.quality &&
       typeof options.quality === 'string' &&
       /(lowest|highest)audio/.test(options.quality);
-    const testAudioFilter = options.filter &&
+    const isAudioFilterRequest = options.filter &&
       typeof options.filter === 'string' &&
       /audio(only)?/.test(options.filter);
 
-    if (testAudioQuality || testAudioFilter) {
+    if (isAudioQualityRequest || isAudioFilterRequest) {
       formats = formats.filter(fmt => fmt.isHLS);
-      if (testAudioQuality) {
-        switch (options.quality) {
-          case 'highestaudio':
-            formats.sort(sortFormatsByHighAudioAndLowVideo);
-            format = formats[0];
-            break;
 
-          case 'lowestaudio':
-            format = formats[formats.length - 1];
-            break;
-        }
+      if (isAudioQualityRequest && options.quality === 'lowestaudio') {
+        format = formats[formats.length - 1];
       } else {
         formats.sort(sortFormatsByHighAudioAndLowVideo);
         format = formats[0];
       }
+
       return format;
     }
   }

--- a/test/format-utils-test.js
+++ b/test/format-utils-test.js
@@ -147,6 +147,85 @@ const formats = [
     hasAudio: false,
   },
 ];
+
+const formatsWithHLS = formats.slice();
+formatsWithHLS.push(
+  {
+    itag: '96',
+    mimeType: 'video/ts; codecs="H.264, aac"',
+    container: 'ts',
+    qualityLabel: '1080p',
+    codecs: 'H.264, aac',
+    videoCodec: 'H.264',
+    audioCodec: 'aac',
+    bitrate: 2500000,
+    audioBitrate: 256,
+    url: 'https://googlevideo.com/',
+    hasVideo: true,
+    hasAudio: true,
+    isHLS: true,
+  },
+  {
+    itag: '95',
+    mimeType: 'video/ts; codecs="H.264, aac"',
+    container: 'ts',
+    qualityLabel: '720p',
+    codecs: 'H.264, aac',
+    videoCodec: 'H.264',
+    audioCodec: 'aac',
+    bitrate: 1500000,
+    audioBitrate: 256,
+    url: 'https://googlevideo.com/',
+    hasVideo: true,
+    hasAudio: true,
+    isHLS: true,
+  },
+  {
+    itag: '94',
+    mimeType: 'video/ts; codecs="H.264, aac"',
+    container: 'ts',
+    qualityLabel: '480p',
+    codecs: 'H.264, aac',
+    videoCodec: 'H.264',
+    audioCodec: 'aac',
+    bitrate: 800000,
+    audioBitrate: 128,
+    url: 'https://googlevideo.com/',
+    hasVideo: true,
+    hasAudio: true,
+    isHLS: true,
+  },
+  {
+    itag: '92',
+    mimeType: 'video/ts; codecs="H.264, aac"',
+    container: 'ts',
+    qualityLabel: '240p',
+    codecs: 'H.264, aac',
+    videoCodec: 'H.264',
+    audioCodec: 'aac',
+    bitrate: 150000,
+    audioBitrate: 48,
+    url: 'https://googlevideo.com/',
+    hasVideo: true,
+    hasAudio: true,
+    isHLS: true,
+  },
+  {
+    itag: '91',
+    mimeType: 'video/ts; codecs="H.264, aac"',
+    container: 'ts',
+    qualityLabel: '144p',
+    codecs: 'H.264, aac',
+    videoCodec: 'H.264',
+    audioCodec: 'aac',
+    bitrate: 100000,
+    audioBitrate: 48,
+    url: 'https://googlevideo.com/',
+    hasVideo: true,
+    hasAudio: true,
+    isHLS: true,
+  },
+);
 const getItags = format => format.itag;
 
 
@@ -191,12 +270,26 @@ describe('chooseFormat', () => {
       const format = chooseFormat(formats, { quality: 'highestaudio' });
       assert.strictEqual(format.itag, '43');
     });
+
+    describe('and HLS formats are present', () => {
+      it('Chooses highest audio itag', () => {
+        const format = chooseFormat(formatsWithHLS, { quality: 'highestaudio' });
+        assert.strictEqual(format.itag, '95');
+      });
+    });
   });
 
   describe('With lowest audio quality wanted', () => {
     it('Chooses lowest audio itag', () => {
       const format = chooseFormat(formats, { quality: 'lowestaudio' });
       assert.strictEqual(format.itag, '17');
+    });
+
+    describe('and HLS formats are present', () => {
+      it('Chooses lowest audio itag', () => {
+        const format = chooseFormat(formatsWithHLS, { quality: 'lowestaudio' });
+        assert.strictEqual(format.itag, '91');
+      });
     });
   });
 
@@ -258,6 +351,24 @@ describe('chooseFormat', () => {
           filter: format => format.container === 'mp4',
         });
         assert.strictEqual(choosenFormat.itag, '18');
+      });
+    });
+
+    describe('that matches audio only formats', () => {
+      describe('and HLS formats are present', () => {
+        it('Chooses a format', () => {
+          const choosenFormat = chooseFormat(formatsWithHLS, { filter: 'audioonly' });
+          assert.strictEqual(choosenFormat.itag, '95');
+        });
+      });
+    });
+
+    describe('that matches formats that contain audio', () => {
+      describe('and HLS formats are present', () => {
+        it('Chooses a format', () => {
+          const choosenFormat = chooseFormat(formatsWithHLS, { filter: 'audio' });
+          assert.strictEqual(choosenFormat.itag, '95');
+        });
       });
     });
 


### PR DESCRIPTION
Closes #886

When providing a live stream video ID and audio only related options to either `quality` or `filter`, the library tends to pick out the only format with audio without video that exists, which tends to be a 5 second long stream.

YouTube seems to be using this stream in their live videos, but it has to re-request it with different parameters every few seconds.

I'm not entirely sure how the mechanism behind it works (it probably just needs to merge the segments in a certain way) or if the library will ever implement that, so for now, this is good way to not return that usually useless format to the user.

~EDIT: I haven't written tests, but I have manually tested it fully.~
EDIT2: Tests have now been written (I don't usually write tests though, so let me know if I need to change anything)