### PR TITLE
fix: add html5 param to fetching of VideoInfoPage

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -330,6 +330,7 @@ const getVideoInfoPage = async(id, options) => {
   url.searchParams.set('ps', 'default');
   url.searchParams.set('gl', 'US');
   url.searchParams.set('hl', options.lang || 'en');
+  url.searchParams.set('html5', '1');
   const body = await utils.exposedMiniget(url.toString(), options).text();
   let info = querystring.parse(body);
   info.player_response = findPlayerResponse('get_video_info', info);

--- a/test/irl-test.js
+++ b/test/irl-test.js
@@ -5,7 +5,7 @@ const ytdl = require('..');
 
 const videos = {
   'Regular video': 'mgOS64BF2eU',
-  'Age restricted': 'LuZu9N53Vd0',
+  'Age restricted': 'Zc09khxyXfA',
   'Embed domain restricted': 'B3eAMGXFw1o',
   'No embed allowed': 'GFg8BP01F5Q',
   Offensive: 'hCKDsjLt_qU',


### PR DESCRIPTION
this makes age-restricted videos work again, although quite slow.
it also fixes the test for age restricted videos, as the old one was deleted.