### PR TITLE
Add parameters to `get_video_info` endpoint to fix 404 errors

### DIFF
--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -282,8 +282,9 @@ exports.cleanVideoDetails = (videoDetails, info) => {
 
   // Use more reliable `lengthSeconds` from `playerMicroformatRenderer`.
   videoDetails.lengthSeconds =
-    info.player_response.microformat &&
-    info.player_response.microformat.playerMicroformatRenderer.lengthSeconds || info.player_response.videoDetails.lengthSeconds;
+    (info.player_response.microformat &&
+    info.player_response.microformat.playerMicroformatRenderer.lengthSeconds) ||
+    info.player_response.videoDetails.lengthSeconds;
   return videoDetails;
 };
 

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -283,7 +283,7 @@ exports.cleanVideoDetails = (videoDetails, info) => {
   // Use more reliable `lengthSeconds` from `playerMicroformatRenderer`.
   videoDetails.lengthSeconds =
     info.player_response.microformat &&
-    info.player_response.microformat.playerMicroformatRenderer.lengthSeconds || info.player_response.lengthSeconds;
+    info.player_response.microformat.playerMicroformatRenderer.lengthSeconds || info.player_response.videoDetails.lengthSeconds;
   return videoDetails;
 };
 

--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -283,7 +283,7 @@ exports.cleanVideoDetails = (videoDetails, info) => {
   // Use more reliable `lengthSeconds` from `playerMicroformatRenderer`.
   videoDetails.lengthSeconds =
     info.player_response.microformat &&
-    info.player_response.microformat.playerMicroformatRenderer.lengthSeconds;
+    info.player_response.microformat.playerMicroformatRenderer.lengthSeconds || info.player_response.lengthSeconds;
   return videoDetails;
 };
 

--- a/lib/info.js
+++ b/lib/info.js
@@ -325,6 +325,8 @@ const VIDEO_EURL = 'https://youtube.googleapis.com/v/';
 const getVideoInfoPage = async(id, options) => {
   const url = new URL(`https://${INFO_HOST}${INFO_PATH}`);
   url.searchParams.set('video_id', id);
+  url.searchParams.set('c', 'TVHTML5');
+  url.searchParams.set('cver', '7.20190319');
   url.searchParams.set('eurl', VIDEO_EURL + id);
   url.searchParams.set('ps', 'default');
   url.searchParams.set('gl', 'US');

--- a/lib/info.js
+++ b/lib/info.js
@@ -275,7 +275,7 @@ const getWatchJSONPage = async(id, options) => {
   let cookie = reqOptions.headers.Cookie || reqOptions.headers.cookie;
   reqOptions.headers = Object.assign({
     'x-youtube-client-name': '1',
-    'x-youtube-client-version': '2.20201203.06.00',
+    'x-youtube-client-version': cver,
     'x-youtube-identity-token': exports.cookieCache.get(cookie || 'browser') || '',
   }, reqOptions.headers);
 

--- a/lib/info.js
+++ b/lib/info.js
@@ -18,6 +18,8 @@ const BASE_URL = 'https://www.youtube.com/watch?v=';
 exports.cache = new Cache();
 exports.cookieCache = new Cache(1000 * 60 * 60 * 24);
 exports.watchPageCache = new Cache();
+// Cache for cver used in getVideoInfoPage
+let cver = '2.20210622.10.00';
 
 
 // Special error class used to determine if an error is unrecoverable,
@@ -307,6 +309,7 @@ const getWatchHTMLPage = async(id, options) => {
   let body = await getWatchHTMLPageBody(id, options);
   let info = { page: 'watch' };
   try {
+    cver = utils.between(body, '{"key":"cver","value":"', '"}');
     info.player_response = findJSON('watch.html', 'player_response',
       body, /\bytInitialPlayerResponse\s*=\s*\{/i, '\n', '{');
   } catch (err) {
@@ -326,7 +329,7 @@ const getVideoInfoPage = async(id, options) => {
   const url = new URL(`https://${INFO_HOST}${INFO_PATH}`);
   url.searchParams.set('video_id', id);
   url.searchParams.set('c', 'TVHTML5');
-  url.searchParams.set('cver', '7.20190319');
+  url.searchParams.set('cver', `7${cver.substr(1)}`);
   url.searchParams.set('eurl', VIDEO_EURL + id);
   url.searchParams.set('ps', 'default');
   url.searchParams.set('gl', 'US');


### PR DESCRIPTION
This fixes 404 errors.
See https://github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/issues/18#issuecomment-864315540 for more information about this issue

Fixes #939