### PR TITLE
release version 4.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ytdl-core",
-  "version": "0.0.0-development",
+  "version": "4.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "video",
     "download"
   ],
-  "version": "0.0.0-development",
+  "version": "4.8.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/fent/node-ytdl-core.git"


### PR DESCRIPTION
version 4.8.2 follows many bugs like [status error code 404](https://github.com/fent/node-ytdl-core/issues/939)
which you cannot when using npm or when hosting a bot or a server and you want to use ytdl-core.

[this pr fixed it of course](https://github.com/fent/node-ytdl-core/commit/d1f535712410eebd79a7468abd07d94f8c4ebe5a) but you cannot use the latest version of the git repository with a program that only allows npm modules like aws and so

anyway, please bump the release version to 4.8.3 asap