### PR TITLE
Fixed URL decection

### DIFF
--- a/lib/url-utils.js
+++ b/lib/url-utils.js
@@ -28,7 +28,7 @@ exports.getURLVideoID = link => {
   let id = parsed.searchParams.get('v');
   if (validPathDomains.test(link) && !id) {
     const paths = parsed.pathname.split('/');
-    id = paths[2];
+    id = paths[1] === "v" ? paths[2] : paths[1];
   } else if (parsed.hostname && !validQueryDomains.has(parsed.hostname)) {
     throw Error('Not a YouTube domain');
   }

--- a/lib/url-utils.js
+++ b/lib/url-utils.js
@@ -28,7 +28,7 @@ exports.getURLVideoID = link => {
   let id = parsed.searchParams.get('v');
   if (validPathDomains.test(link) && !id) {
     const paths = parsed.pathname.split('/');
-    id = paths[1] === 'v' ? paths[2] : paths[1];
+    id = parsed.host === 'youtu.be' ? paths[1] : paths[2];
   } else if (parsed.hostname && !validQueryDomains.has(parsed.hostname)) {
     throw Error('Not a YouTube domain');
   }

--- a/lib/url-utils.js
+++ b/lib/url-utils.js
@@ -22,13 +22,13 @@ const validQueryDomains = new Set([
   'music.youtube.com',
   'gaming.youtube.com',
 ]);
-const validPathDomains = /^https?:\/\/(youtu\.be\/|(www\.)?youtube.com\/(embed|v|shorts)\/)/;
+const validPathDomains = /^https?:\/\/(youtu\.be\/|(www\.)?youtube\.com\/(embed|v|shorts)\/)/;
 exports.getURLVideoID = link => {
   const parsed = new URL(link);
   let id = parsed.searchParams.get('v');
   if (validPathDomains.test(link) && !id) {
     const paths = parsed.pathname.split('/');
-    id = paths[paths.length - 1];
+    id = paths[2];
   } else if (parsed.hostname && !validQueryDomains.has(parsed.hostname)) {
     throw Error('Not a YouTube domain');
   }

--- a/lib/url-utils.js
+++ b/lib/url-utils.js
@@ -28,7 +28,7 @@ exports.getURLVideoID = link => {
   let id = parsed.searchParams.get('v');
   if (validPathDomains.test(link) && !id) {
     const paths = parsed.pathname.split('/');
-    id = paths[1] === "v" ? paths[2] : paths[1];
+    id = paths[1] === 'v' ? paths[2] : paths[1];
   } else if (parsed.hostname && !validQueryDomains.has(parsed.hostname)) {
     throw Error('Not a YouTube domain');
   }

--- a/test/url-utils-test.js
+++ b/test/url-utils-test.js
@@ -19,6 +19,8 @@ describe('getURLVideoID()', () => {
     assert.strictEqual(id, 'RAW_VIDEOID');
     id = getVideoID('http://youtube.com/shorts/RAW_VIDEOID');
     assert.strictEqual(id, 'RAW_VIDEOID');
+    id = getVideoID("http://youtube.com/v/RAW_VIDEOID/FakeVideoID");
+    assert.strictEqual(id, "RAW_VIDEOID");
     id = getVideoID('https://music.youtube.com/watch?v=RAW_VIDEOID&list=RDAMVMmtLgabce8KQ');
     assert.strictEqual(id, 'RAW_VIDEOID');
     id = getVideoID('https://gaming.youtube.com/watch?v=RAW_VIDEOID');
@@ -59,6 +61,8 @@ describe('getVideoID()', () => {
     assert.strictEqual(id, 'RAW_VIDEOID');
     id = getVideoID('http://youtube.com/shorts/RAW_VIDEOID');
     assert.strictEqual(id, 'RAW_VIDEOID');
+    id = getVideoID("http://youtube.com/v/RAW_VIDEOID/FakeVideoID");
+    assert.strictEqual(id, "RAW_VIDEOID");
     id = getVideoID('_LENGTH_11_');
     assert.strictEqual(id, '_LENGTH_11_');
     assert.throws(() => {

--- a/test/url-utils-test.js
+++ b/test/url-utils-test.js
@@ -19,8 +19,8 @@ describe('getURLVideoID()', () => {
     assert.strictEqual(id, 'RAW_VIDEOID');
     id = getVideoID('http://youtube.com/shorts/RAW_VIDEOID');
     assert.strictEqual(id, 'RAW_VIDEOID');
-    id = getVideoID("http://youtube.com/v/RAW_VIDEOID/FakeVideoID");
-    assert.strictEqual(id, "RAW_VIDEOID");
+    id = getVideoID('http://youtube.com/v/RAW_VIDEOID/FakeVideoID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = getVideoID('https://music.youtube.com/watch?v=RAW_VIDEOID&list=RDAMVMmtLgabce8KQ');
     assert.strictEqual(id, 'RAW_VIDEOID');
     id = getVideoID('https://gaming.youtube.com/watch?v=RAW_VIDEOID');
@@ -61,8 +61,8 @@ describe('getVideoID()', () => {
     assert.strictEqual(id, 'RAW_VIDEOID');
     id = getVideoID('http://youtube.com/shorts/RAW_VIDEOID');
     assert.strictEqual(id, 'RAW_VIDEOID');
-    id = getVideoID("http://youtube.com/v/RAW_VIDEOID/FakeVideoID");
-    assert.strictEqual(id, "RAW_VIDEOID");
+    id = getVideoID('http://youtube.com/v/RAW_VIDEOID/FakeVideoID');
+    assert.strictEqual(id, 'RAW_VIDEOID');
     id = getVideoID('_LENGTH_11_');
     assert.strictEqual(id, '_LENGTH_11_');
     assert.throws(() => {


### PR DESCRIPTION
Hello, I noticed two bugs in URL detection and decided to fix them.

The first one was causing `validateURL` to be `true` with links like: `https://youtubedcom/v/SBjQ9tuuTJQ` or `http://www.youtube com/embed/SBjQ9tuuTJQ`. (Basically allowing any character between "youtube" and "com".)

And the second one made `getURLVideoID` return different id than YouTube would use in links like: `https://youtube.com/v/SBjQ9tuuTJQ/dQw4w9WgXcQ` or `https://youtube.com/SBjQ9tuuTJQ/somethink/somethink/dQw4w9WgXcQ`. (Basically YouTube uses the first string after `/v/` and ytdl was using the one after last `/`.)

I hope I made everything clear and actually helped instead of causing some problems. 😀