### PR TITLE
Handle YT-returns-wrong-length bug by manually setting `stream.end = true` in `end` event.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,10 +148,12 @@ const downloadFromInfoCallback = (stream, info, options) => {
         req.on('data', ondata);
         req.on('end', () => {
           if (stream.destroyed) { return; }
-          if (end && end !== rangeEnd) {
+          if (end && end < rangeEnd) {
             start = end + 1;
             end += dlChunkSize;
             getNextChunk();
+          } else {
+            return pipeAndSetEvents(req, stream, true);
           }
         });
         pipeAndSetEvents(req, stream, shouldEnd);


### PR DESCRIPTION
See issue [#1038](https://github.com/fent/node-ytdl-core/issues/1036) for more info.

TL;DR - YT returns incorrect `content-length` header for some video; this code change handles such errors (somewhat inelegantly); I don't expect maintainers to accept this change because YT is the source of the problem (not ytdl-core); it's here to support other users running into same problem instead.