### PR TITLE
add endTimestamp property under liveBroadcastDetails

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -198,6 +198,7 @@ declare module 'ytdl-core' {
       liveBroadcastDetails?: {
         isLiveNow: boolean;
         startTimestamp: string;
+        endTimestamp?: string;
       };
       uploadDate: string;
     }


### PR DESCRIPTION
This PR will add the typing of property `endTimestamp` under `liveBroadcastDetails` of `MicroformatRenderer` interface.