### PR TITLE
New Feature: getVideoPlaybackURL function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -214,19 +214,12 @@ ytdl.downloadFromInfo = (info, options) => {
 };
 
 ytdl.getFormat = (info, options) => {
-  var format;
-  try {
-    format = formatUtils.chooseFormat(info.formats, options);
-    return format;
-  } catch (e) {
-    throw e;
-  }
+  return formatUtils.chooseFormat(info.formats, options);
 }
 
 ytdl.getVideoPlaybackURL = async (info, options) => {
   if (typeof info != "object") {
     info = await ytdl.getInfo(info);
   }
-  var videoURL = ytdl.getFormat(info, options).url;
-  return videoURL;
+  return ytdl.getFormat(info, options).url;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,6 +227,6 @@ ytdl.getVideoPlaybackURL = async (info, options) => {
   if (typeof info != "object") {
     info = await ytdl.getInfo(info);
   }
-  var videoURL = getFormat(info, options).url;
+  var videoURL = ytdl.getFormat(info, options).url;
   return videoURL;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -212,3 +212,21 @@ ytdl.downloadFromInfo = (info, options) => {
   });
   return stream;
 };
+
+ytdl.getFormat = (info, options) => {
+  var format;
+  try {
+    format = formatUtils.chooseFormat(info.formats, options);
+    return format;
+  } catch (e) {
+    throw e;
+  }
+}
+
+ytdl.getVideoPlaybackURL = async (info, options) => {
+  if (typeof info != "object") {
+    info = await ytdl.getInfo(info);
+  }
+  var videoURL = getFormat(info, options).url;
+  return videoURL;
+}


### PR DESCRIPTION
adds two functions, one is getFormat, and the other is getVideoPlaybackURL. getformat just returns the formatutils.chooseformat without having to do info.formats. getVideoPlaybackURL gets the video playback url, so that you don't have to manually get it, and it's just easier. it doesn't mess with any of the code, and it's a simple addition that might make things easier.