### PR TITLE
fix: likes extraction with the new layout

### DIFF
--- a/lib/info-extras.js
+++ b/lib/info-extras.js
@@ -236,8 +236,7 @@ exports.getLikes = info => {
     let contents = info.response.contents.twoColumnWatchNextResults.results.results.contents;
     let video = contents.find(r => r.videoPrimaryInfoRenderer);
     let buttons = video.videoPrimaryInfoRenderer.videoActions.menuRenderer.topLevelButtons;
-    let like = buttons.find(b => b.toggleButtonRenderer &&
-      b.toggleButtonRenderer.defaultIcon.iconType === 'LIKE');
+    let like = buttons.find(b => b.segmentedLikeDislikeButtonRenderer).segmentedLikeDislikeButtonRenderer.likeButton;
     return parseInt(like.toggleButtonRenderer.defaultText.accessibility.accessibilityData.label.replace(/\D+/g, ''));
   } catch (err) {
     return null;


### PR DESCRIPTION
YouTube recently changed their layout, so the likes need to be extracted differently. Currently ytdl-core returns null for the like count.

closes #1231 