### PR TITLE
Explicitly include range parameter in chunked stream URLs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -143,19 +143,20 @@ const downloadFromInfoCallback = (stream, info, options) => {
         parseInt(format.contentLength);
 
       const getNextChunk = () => {
-        if (!rangeEnd && end >= contentLength) end = 0;
+        if (!rangeEnd && end >= contentLength) end = contentLength;
         if (rangeEnd && end > rangeEnd) end = rangeEnd;
-        shouldEnd = !end || end === rangeEnd;
+        shouldEnd = end === rangeEnd || end === contentLength;
 
         requestOptions.headers = Object.assign({}, requestOptions.headers, {
-          Range: `bytes=${start}-${end || ''}`,
+          Range: `bytes=${start}-${end}`,
         });
 
-        req = miniget(format.url, requestOptions);
+        const requestedUrl = `${format.url}&range=${start}-${end}`;
+        req = miniget(requestedUrl, requestOptions);
         req.on('data', ondata);
         req.on('end', () => {
           if (stream.destroyed) { return; }
-          if (end && end !== rangeEnd) {
+          if (end !== rangeEnd && end !== contentLength) {
             start = end + 1;
             end += dlChunkSize;
             getNextChunk();


### PR DESCRIPTION
First time touching this repo, so not sure if I missed any edge cases, but creating this PR to start the conversation on the permanent fix. Credits to @gatecrasher777 for the idea.

Attempts to resolve #1186, where youtube is throttling requests without the 'range' parameter in the URL. 

Instead of setting `end` to 0 (falsey) as a condition to check for whether to continue chunking, we check whether `end` has reached the end of the file. 