### PR TITLE
Fix: Missing catch or finally after try

### DIFF
--- a/lib/sig.js
+++ b/lib/sig.js
@@ -62,7 +62,7 @@ exports.extractFunctions = body => {
       const ndx = body.indexOf(functionStart);
       if (ndx >= 0) {
         const subBody = body.slice(ndx + functionStart.length);
-        const functionBody = `var ${functionStart}${utils.cutAfterJS(subBody)};${functionName}(ncode);`;
+        const functionBody = `var ${functionStart}${utils.addCatchBlock(utils.cutAfterJS(subBody))};${functionName}(ncode);`;
         functions.push(functionBody);
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -288,7 +288,7 @@ const normalizeIP = exports.normalizeIP = ip => {
 
 /**
  * Adds a catch block to every try block that doesnt has one in the code string.
- * @param String codeString  The code string to add catch blocks to.
+ * @param codeString  The code string to add catch blocks to.
  * @returns  The code string with catch blocks added.
  */
 exports.addCatchBlock = codeString => {
@@ -307,8 +307,8 @@ exports.addCatchBlock = codeString => {
 
 /**
 * Finds the index of the matching brace for the brace at the given index.
-* @param {*} codeString The code string to search in.
-* @param {*} openIndex The index of the open brace to find the matching brace for.
+* @param codeString The code string to search in.
+* @param openIndex The index of the open brace to find the matching brace for.
 * @returns  The index of the matching brace.
 */
 function findMatchingBrace(codeString, openIndex) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,7 +100,7 @@ exports.cutAfterJS = mixedJson => {
     if (!isEscaped && isEscapedObject !== null && mixedJson[i] === isEscapedObject.end) {
       isEscapedObject = null;
       continue;
-    // Might be the start of a new escaped object
+      // Might be the start of a new escaped object
     } else if (!isEscaped && isEscapedObject === null) {
       for (const escaped of ESCAPING_SEQUENZES) {
         if (mixedJson[i] !== escaped.start) continue;
@@ -284,3 +284,40 @@ const normalizeIP = exports.normalizeIP = ip => {
   }
   return fullIP;
 };
+
+
+/**
+ * Adds a catch block to every try block that doesnt has one in the code string.
+ * @param String codeString  The code string to add catch blocks to.
+ * @returns  The code string with catch blocks added.
+ */
+exports.addCatchBlock = codeString => {
+  let tryRegex = /try\s*{/gm;
+  let catchRegex = /^\s*catch\s*\(.*\)/m;
+  let tryMatch;
+  while ((tryMatch = tryRegex.exec(codeString)) !== null) {
+    const openBraceIndex = tryMatch.index + tryMatch[0].length - 1;
+    const closeBraceIndex = findMatchingBrace(codeString, openBraceIndex);
+    const after = codeString.slice(closeBraceIndex + 1);
+    if (!catchRegex.test(after))
+      codeString = codeString.slice(0, closeBraceIndex + 1) + " catch (e) { }" + after;
+  }
+  return codeString;
+}
+
+/**
+* Finds the index of the matching brace for the brace at the given index.
+* @param {*} codeString The code string to search in.
+* @param {*} openIndex The index of the open brace to find the matching brace for.
+* @returns  The index of the matching brace.
+*/
+function findMatchingBrace(codeString, openIndex) {
+  let braceCount = 1;
+  let i = openIndex + 1;
+  while (braceCount > 0 && i < codeString.length) {
+    if (codeString[i] === "{") braceCount++;
+    else if (codeString[i] === "}") braceCount--;
+    i++;
+  }
+  return i - 1;
+}


### PR DESCRIPTION
To resolve the problem of the missing catch block in the YouTube Script, I added some simple code to include the missing catch block in the relevant function. I have tested the built-in tests and did not encounter any errors. If you would like to test the functionality yourself, please update the player script for testing purposes.