### PR TITLE
fix: code parser

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,7 +60,7 @@ const ESCAPING_SEQUENZES = [
   { start: "'", end: "'" },
   { start: '`', end: '`' },
   // RegeEx
-  { start: '/', end: '/', startPrefix: /(^|[[{:;,])\s?$/ },
+  { start: '/', end: '/', startPrefix: /(^|[[{:;,/])\s?$/ },
 ];
 
 /**


### PR DESCRIPTION
Youtube changed `base.js` code, especially this regex `/[{//'],]/` and it broke this package.
This patch will fix the situation, but we need to refactor utils.js code to get stability in the future

Issue: https://github.com/fent/node-ytdl-core/issues/1197